### PR TITLE
Update for Ghidra 11

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ghidra: ['10.3.2', '10.3', '10.3.3', '10.4']
+        ghidra: ['11.0']
         java:   ['17']
 
     steps:

--- a/ghidra_scripts/Ps3ElfUtils.java
+++ b/ghidra_scripts/Ps3ElfUtils.java
@@ -1,6 +1,6 @@
 import ghidra.app.script.GhidraScript;
-import ghidra.framework.project.extensions.ExtensionDetails;
-import ghidra.framework.project.extensions.ExtensionUtils;
+import ghidra.util.extensions.ExtensionDetails;
+import ghidra.util.extensions.ExtensionUtils;
 import ghidra.program.model.address.Address;
 import ghidra.program.model.data.ArrayDataType;
 import ghidra.program.model.data.DataType;


### PR DESCRIPTION
Makes the scripts work on Ghidra 11.0, they moved the `extensions` package again. Not compatible with 10.x so those versions have been removed from the workflow.