### PR TITLE
Add dist to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 .gradle
 build
+dist


### PR DESCRIPTION
So that extension zips don't accidentally get committed (because I'm not always that careful).