### PR TITLE
Add build targets for Ghidra 11.4.1 and 11.4.2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,8 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ghidra: ['11.2', '11.2.1', '11.3', '11.3.1', '11.3.2', '11.4']
+        ghidra: ['11.2', '11.2.1', '11.3', '11.3.1', '11.3.2', '11.4', '11.4.1', '11.4.2']
         java:   ['21']
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
       - name: Checkout


### PR DESCRIPTION
I needed builds supporting the two most recent Ghidra versions, so I modified the CI workflow to build for both Ghidra 11.4.1 and 11.4.2, I tested it locally and it seems to work fine.

I also modified the workflow to use `GITHUB_TOKEN` to avoid GitHub API rate-limit errors - like what seemed to happen with the most recent build in this repo.

Hopefully this is all good, just thought I'd open a PR as I figure someone else probably wants to use this with the latest Ghidra builds :smile: 