### PR TITLE
Improve existing NID demangling

### DIFF
--- a/data/nids.txt
+++ b/data/nids.txt
@@ -26,8 +26,8 @@
 0x2F5CD187 sceSmartTargetTrackingStart
 0x6A7495E5 sceSmartTargetTrackingStop
 0x993DFCDC sceSmartTargetTrackingUnregisterTarget
-0x92A609B2 _ZN2ss17update_manager_if17set_hdd_copy_modeEh
-0xDDB635E1 _ZN2ss17update_manager_if22set_fself_control_flagEh
+0x92A609B2 ss::update_manager_if::set_hdd_copy_mode(unsigned char)
+0xDDB635E1 ss::update_manager_if::set_fself_control_flag(unsigned char)
 0xEF7A58EA sceSdCleanList
 0xDBEB7F81 pemuNotifyCallback
 0x45EABEC0 pemuGetSystemTimeWide
@@ -1010,57 +1010,57 @@
 0x74A2A1FE cellCryptoPuSha1Hmac
 0xA60023EF FT_Outline_New
 0xAFCFDAD7 _Lgamma
-0xE54F1FE0 _ZNKSt9bad_alloc8_DoraiseEv
+0xE54F1FE0 std::bad_alloc::_Doraise() const
 0x4654E796 FT_Get_Module
 0x44A20E79 cellSailGraphicsAdapterUpdateAvSync
-0x8DD1CBB0 _ZNK3paf7PhMicon9IsPlayingEi
+0x8DD1CBB0 paf::PhMicon::IsPlaying(int) const
 0x0A242ED5 sinf4
 0xFB12B7FC cellDtcpIpSuspendActivationForDebug
 0x496B71D4 cellGcmSysStealChannel
 0xEE41E16A cellRudpBind
-0x83B2CC6F _Znwj
+0x83B2CC6F operator new(unsigned int)
 0x6FC530B3 UTF16toUCS2
 0x679E8CAF sce_paf_private_realloc
 0xC9C7A236 sceNpInstallerTerm
-0xBA0B6300 _ZNSt9basic_iosIwSt11char_traitsIwEED1Ev
+0xBA0B6300 std::basic_ios<wchar_t, std::char_traits<wchar_t>>::~basic_ios()
 0xB6FEB84B cellHttpClientSetTransactionStateCallback
-0x613A24BF _ZN3paf8PhWidget13UpdateCamerasEv
+0x613A24BF paf::PhWidget::UpdateCameras()
 0x6EB168B3 cellMinisSaveDataDelete
 0x62A20F0D cellFiberPpuUtilWorkerControlConnectEventQueueToSpurs
 0xE665F9A9 cellFiberPpuSchedulerTraceStop
 0xA8CF8451 sceNpSignalingDestroyCtx
 0x545E08CB cellDtcpIpInitializeEx
 0xB5E28191 _FSin
-0x5A85BEFC _ZN3paf10PhCheckBox8SetCheckEbb
+0x5A85BEFC paf::PhCheckBox::SetCheck(bool, bool)
 0xE163977F cellPngDecGetPLTE
 0x67794933 smf_ApRc_SetAudioProfileInfo
 0x9F65BD34 fdimf4
 0x5A8A8B0F cellRecGetInfo
-0x7008E209 _ZNKSt5ctypeIwE10do_toupperEw
+0x7008E209 std::ctype<wchar_t>::do_toupper(wchar_t) const
 0x64951AC7 cellUsbdUnregisterLdd
 0x2AED8936 sqlite3_finalize
-0x4F5319E0 _ZNK3paf6PhText14GetCurrentLineEv
+0x4F5319E0 paf::PhText::GetCurrentLine() const
 0x30B5530B cellFsUtilityDf
 0x95ED21D8 cellGcmCgGetParameterSemantic
 0x45440B57 cellGcmCgGetParameterResourceIndex
 0x5F7C7A6F cellSailPlayerSetParameter
-0x094CD214 _ZN3paf6PhList17PushBackLabelTextEi
+0x094CD214 paf::PhList::PushBackLabelText(int)
 0x92A76580 SSL_CTX_free
 0xB6BBCD5D cellVdecOpen
-0xD81578DB _ZN3vsh14BottomBar_OpenEPN3paf4ViewEPKcS4_RNS_21BottomBarInstanceDataEi
+0xD81578DB vsh::BottomBar_Open(paf::View*, char const*, char const*, vsh::BottomBarInstanceData&, int)
 0xF93027E0 smvd4GetMemorySize
 0x59EF6A10 cellGcmSetFifo
 0x6BB85B12 sceNpUtilSetEnv
 0xFB08A795 sceNetUpnpStop
 0xC69B2427 labs
-0xE82A422D _ZNKSt8numpunctIwE11do_truenameEv
+0xE82A422D std::numpunct<wchar_t>::do_truename() const
 0x8CE7166D CEComFree
 0xBA136594 csinf
 0x4219DE31 cellGemEnableCameraPitchAngleCorrection
 0x642C0E15 cellCryptoPuRsadp2048CRT
 0xA5F12145 cellWebBrowserCreate2
 0x95AE2CDE cellSaveDataUserFixedExport
-0xFBC581BF _ZN12bXCeAttrList12AddAttributeEPcS0_
+0xFBC581BF bXCeAttrList::AddAttribute(char*, char*)
 0x73EAE03D strrchr
 0xB2336BA7 cellMusicSelectContents
 0x0DBB3F51 SSL_clear
@@ -1070,14 +1070,14 @@
 0x05BD4438 sys_net_get_udpp2p_test_param
 0x9A919775 sceNpSignalingGetConnectionFromNpIdVsh
 0xAF6BDCB0 _Nonfatal_Assert
-0xE8FE972B _ZN3paf7PhMicon6EnableEib
+0xE8FE972B paf::PhMicon::Enable(int, bool)
 0x1D5BF5D0 _modff4
 0xE1E83C65 strncmp
 0x19610523 svc1dFlushPicture
 0x074CD5B5 SSL_CIPHER_get_id
 0xDF0120C2 _cellSpursJobQueuePushFlush
 0x2EF701EC cellMusicDecodeSetDecodeCommand2
-0x49323F47 _Z18xcbGetAbsolutePathPvPcPi
+0x49323F47 xcbGetAbsolutePath(void*, char*, int*)
 0x40A2599A atol
 0xBDFD51E2 cellMicSysShareStop
 0x15B0B0CD cellVideoOutGetConfiguration
@@ -1086,7 +1086,7 @@
 0xFB87CF5E sceNpLookupDestroyTransactionCtx
 0xA397D042 cellFsLseek
 0x7585A275 cellPngDecGetbKGD
-0xFEAD5829 _ZN3Ime21RegisterPanelCallbackEPNS_20OskpanelCallbackListE
+0xFEAD5829 Ime::RegisterPanelCallback(Ime::OskpanelCallbackList*)
 0x68A843EC _cellAudioPathThruSpdifGetIndexPtr
 0x18BCD21B cellSailPlayerSetGraphicsAdapter
 0x3DD9639A cellSailAuReceiverInitialize
@@ -1101,7 +1101,7 @@
 0x59743B2B sceNpClansSendMembershipRequest
 0xDFD899B7 cellSailComposerTryGetEsVideoAu
 0x6DB6E8CD socketclose
-0xF5C65829 _ZNK3paf8PhWidget9IsInheritEPKc
+0xF5C65829 paf::PhWidget::IsInherit(char const*) const
 0x0B45CD84 cellSysutilAvc2ShowScreen
 0xE3FBF64D cellUsbPspcmRegister
 0xF7583D67 vscanf
@@ -1114,16 +1114,16 @@
 0x57D952B1 dlnaPrintCancelJob
 0xC3417866 sceNpGetTicketParam
 0xE4645AF8 cellAudioOutSetDeviceMode
-0x1692AE0C _ZNSt6localeD1Ev
-0x53693D40 _ZSt11setiosflagsNSt5_IosbIiE9_FmtflagsE
-0x9AFA5D71 _ZNSt10money_baseD2Ev
-0xA79C4516 _ZNSt15basic_streambufIcSt11char_traitsIcEED0Ev
+0x1692AE0C std::locale::~locale()
+0x53693D40 std::setiosflags(std::_Iosb<int>::_Fmtflags)
+0x9AFA5D71 std::money_base::~money_base()
+0xA79C4516 std::basic_streambuf<char, std::char_traits<char>>::~basic_streambuf()
 0x31B2B978 sceNpMatchingJoinRoomWithoutGUI
 0xCED4DDA9 cellFontGetRenderEffectSlant
 0xF78A4A76 FT_Atan2
 0x04CA5E6A sceNpScoreRecordGameData
 0x7D94CA36 cellSysutilAvcGetVideoMuting
-0x0A9E290A _ZNK3paf8PhWidget7GetTextERSbIwSt11char_traitsIwESaIwEEi
+0x0A9E290A paf::PhWidget::GetText(std::basic_string<wchar_t, std::char_traits<wchar_t>, std::allocator<wchar_t>>&, int) const
 0x46B66F76 csqrtl
 0x2F24FEA3 cellVoiceUpdatePort
 0x1FF82B63 cellFsLsnLock
@@ -1141,22 +1141,22 @@
 0x72DEE049 _QN4cell5Daisy29LFQueue2HasUnfinishedConsumerEPNS0_8LFQueue2Ej
 0x16EAF5F1 UHCstoEUCKRs
 0xD276FF1F cellHttpEnd
-0x9E741D47 _ZNSsC1ERKSs
+0x9E741D47 std::basic_string<char, std::char_traits<char>, std::allocator<char>>::basic_string(std::basic_string<char, std::char_traits<char>, std::allocator<char>> const&)
 0x0591826F cellSearchStartContentSearch
 0x64A704CC sceNpBasicRecvMessageAttachmentLoad
 0x7A52BF69 cellSailRecorderInitialize
 0x061049AD cellFontGraphicsSetFontRGBA
 0x122AF93C sceNpC7yLookupTssImageResultVsh
-0x6DBBB9DE _ZNKSt5ctypeIcE10do_toupperEc
-0x0D84691B _ZN4vec4C1Ef
+0x6DBBB9DE std::ctype<char>::do_toupper(char) const
+0x0D84691B vec4::vec4(float)
 0x0A4C8295 cellSearchStartListSearch
 0x11F777B7 cellNetCtlGetInfoGameInt
 0xC73ED848 cellJpgDecSpSetOpenMode
-0xAB2B0674 _ZN3paf10PhSaveData11SetRotationEf
+0xAB2B0674 paf::PhSaveData::SetRotation(float)
 0x6261C0B5 _log10f4
 0x14208B00 _asinf4fast
-0xC6BAFADE _ZN3paf7PhModel16SetCurrentMotionEif
-0xE8355FCC _ZNK3paf6PhText12GetLineCountEv
+0xC6BAFADE paf::PhModel::SetCurrentMotion(int, float)
+0xE8355FCC paf::PhText::GetLineCount() const
 0x8B300F66 cellJpgDecExtCreate
 0x6D5115B0 wcsncmp
 0x49A3426D cellSpursReadyCountSwap
@@ -1167,15 +1167,15 @@
 0x27F86D70 cellHttpClientCloseConnections
 0xAF57D9C9 sceNpCommerceGetCurrencyDecimals
 0xE16DE678 cellSailVideoConverterCanGetResult
-0xA90C4FF2 _ZNSt8time_getIcSt19istreambuf_iteratorIcSt11char_traitsIcEEE7_GetcatEPPKNSt6locale5facetE
+0xA90C4FF2 std::time_get<char, std::istreambuf_iterator<char, std::char_traits<char>>>::_Getcat(std::locale::facet const**)
 0x8A4CB646 cellWebBrowserCreateWithConfig
-0xE4B244BE _ZN3paf9PhNumSpin8SetStyleEiif
+0xE4B244BE paf::PhNumSpin::SetStyle(int, int, float)
 0x7C95FEB8 cellOskDialogExtInputDeviceLock
 0x795B12B3 cellPrintStartJob
 0x4D1A1BC3 dlnaPrintStartJob
 0xFFFE79BF _LCmulcc
-0x9B8558F4 _ZN13PSJSValueImpl11NewFromPoolERK11PSJSContextb
-0x3D0E1B43 _ZN11PSJSContext17SetStdErrCallbackEPFvPKtiPvES2_
+0x9B8558F4 PSJSValueImpl::NewFromPool(PSJSContext const&, bool)
+0x3D0E1B43 PSJSContext::SetStdErrCallback(void (*)(unsigned short const*, int, void*), void*)
 0xCFDF24BB cellVideoOutDebugSetMonitorType
 0x67ECB719 CEULock_create
 0x9EBA183C FT_Library_Version
@@ -1183,23 +1183,23 @@
 0xA9E039C4 erfcf
 0x714C9618 __raw_spu_putfld
 0x40C4523A smf_ApRc_AddCompatibleBrand
-0x0DF5ACF4 _ZNK3paf5PhWeb16GetCharactorSizeEv
+0x0DF5ACF4 paf::PhWeb::GetCharactorSize() const
 0x813A9666 ungetwc
-0xAA5755FA _ZN3paf5Image4CopyEv
+0xAA5755FA paf::Image::Copy()
 0xA26A2E9C FT_Alloc
 0x2CEB945C smf_FTell
 0x1B5BDCC6 cellHttpAddCookieWithClientId
 0xA7F9E716 cellSpursGetWorkloadData
 0x31DB8C89 atan2
 0xF644E687 cellGcmSetLogicOp
-0x3191108C _ZNK3paf7PhMicon7GetLoopEv
-0x57419947 _Z27xcbAssignDefaultNewFileNamePvS_PKcS1_S1_S1_Pc
+0x3191108C paf::PhMicon::GetLoop() const
+0x57419947 xcbAssignDefaultNewFileName(void*, void*, char const*, char const*, char const*, char const*, char*)
 0x32FEBB4C sceNpMatchingSearchJoinRoomGUI
 0xD33AD4D0 cellHttpAuthCacheSetEntryMax
 0x9281E87A sceNpCommerceGetDataFlagFinish
 0x9E1DFF96 cellGemGetInfo
 0xA1912CAC sjvtdGetMemorySize2
-0xF127E816 _ZNSt10istrstreamD1Ev
+0xF127E816 std::istrstream::~istrstream()
 0x425E8440 cellMgVideoClearMACList
 0xEE698B61 xUSBMassDestroyInstance
 0x182D9890 cellSpursRequestIdleSpu
@@ -1207,11 +1207,11 @@
 0x430CE063 sceNpMatching2AbortContextStart
 0xA01698C9 pafGuSetDrawSurfW
 0x7C912BDA kuten2jis
-0xDF5E3BFD _ZN3paf4View15SetDrawPriorityEi
+0xDF5E3BFD paf::View::SetDrawPriority(int)
 0xEEFFC9A6 _wrename
 0xCE81C7F0 sceNpLookupCreateTitleCtx
 0xECDDBA69 _WStodx
-0x7893B654 _ZN3paf9PhNumSpinD2Ev
+0x7893B654 paf::PhNumSpin::~PhNumSpin()
 0x0F8A3B6B cellWebBrowserConfigSetMimeSet
 0x9AA6A321 cellRudpAccept
 0xDB215455 cellRtcAlarmGetStatus
@@ -1219,13 +1219,13 @@
 0xAA9ED7FF sceNpSnsFbCheckConfig
 0x2627D6B2 erfc
 0x61DFBE83 cellCameraPrepExtensionUnit
-0xDFE8806F _ZN3paf6ThreadC2EijPKcj
-0xB35AAC2B _ZN3paf8PhXmList10UpdateItemEi
+0xDFE8806F paf::Thread::Thread(int, unsigned int, char const*, unsigned int)
+0xB35AAC2B paf::PhXmList::UpdateItem(int)
 0x1E287E88 FT_Get_Glyph_Name
-0x5AAA5547 _ZN3paf5Sound6Output20AllocateAudioChannelEv
+0x5AAA5547 paf::Sound::Output::AllocateAudioChannel()
 0x3C7E4CE0 pafGuScissor
 0x2A6FBA9C cellGcmIoOffsetToAddress
-0x0563627C _ZN4cell5Daisy17LFQueue2PushCloseEPNS0_8LFQueue2EPFiPvjE
+0x0563627C cell::Daisy::LFQueue2PushClose(cell::Daisy::LFQueue2*, int (*)(void*, unsigned int))
 0x55A3349F sceNpMatchingSetRoomInfoVsh
 0x231D5941 cellFontGlyphGetHorizontalShift
 0x32A1BD52 FT_CMap_New
@@ -1233,7 +1233,7 @@
 0x72086315 cellFiberPpuContextInitialize
 0x983BE7FC _cellSpursCreateJobQueueWithJobDescriptorPool
 0x2033EEB7 csqrt
-0x88161054 _ZN3paf8PhWidget8SetStyleEiii
+0x88161054 paf::PhWidget::SetStyle(int, int, int)
 0x4636DE94 _cellAudioPathThroughLRCK_setBufferForm
 0x8C97A96C cellSpursShutdownJobQueue
 0x3929948D cellSyncQueueInitialize
@@ -1248,7 +1248,7 @@
 0xE48348E9 vprintf
 0x7D73E7CD inflateInit_
 0xDDBAC025 strcasecmp_ascii
-0xD4BA5B31 _ZNSt8_LocinfoC2EPKc
+0xD4BA5B31 std::_Locinfo::_Locinfo(char const*)
 0x32FAAF58 cellHttpUtilParseUri
 0x2070C99E cellDtcpIpSetByteSeekRange
 0xF0EC3CCC cellOskDialogSetLayoutMode
@@ -1257,15 +1257,15 @@
 0x4CCE88A9 cellSpursLookUpTasksetAddress
 0x653969A5 sceFimPresenceUnregisterCb
 0x3DBD2314 cellSaveDataListSave
-0x891CC76B _ZN11PSJSContext12RegistGlobalEPKcP13PSJSValueImpl
-0xC7931798 _ZNKSt12_String_base5_XranEv
+0x891CC76B PSJSContext::RegistGlobal(char const*, PSJSValueImpl*)
+0xC7931798 std::_String_base::_Xran() const
 0x4EC8C141 cellVideoOutConvertCursorColor
 0x6BF6F832 cellFontSetFontsetOpenMode
 0xCB588DBA cellFsFGetBlockSize
 0x4559999E sceNpSignalingGetPeerNetInfoVsh
 0x1872331B cellSailGraphicsAdapterPtsToTimePosition
 0xB40CA175 cellPngDecGetTextChunk
-0xD385A4FC _ZN3paf16Job_DestroyQueueEPNS_9Job_QueueE
+0xD385A4FC paf::Job_DestroyQueue(paf::Job_Queue*)
 0x5EF96465 _cellSpursEventFlagInitialize
 0x5202E53B cellSpursJobChainSetExceptionEventHandler
 0x5209A062 divx311DecClose
@@ -1274,15 +1274,15 @@
 0x4014C246 cellMusicSetVolume2
 0x6F0F7667 cellHttpUtilBuildUri
 0x9CA05AEC cellM4hdEncGetResult
-0xE0A3AA72 _Z10normalize3RK4vec4
+0xE0A3AA72 normalize3(vec4 const&)
 0x16FA740A xCore_GetInterface
-0x059D2C50 _ZNK7bXCeDoc10GetDocRootEv
+0x059D2C50 bXCeDoc::GetDocRoot() const
 0x4E4BE299 longjmp
 0x8F122EF8 cellSpursTasksetAttributeSetTasksetSize
 0x8D1B77FB sys_net_abort_socket
 0x594266BE sceFimPresenceGetInitialPresence
 0x9DC040E4 _Deletegloballocale
-0xFD1AD2B9 _ZN3Ime21imeSingleInputContext14addEventLisnerEPNS_14OskImeListenerE
+0xFD1AD2B9 Ime::imeSingleInputContext::addEventLisner(Ime::OskImeListener*)
 0xD2B978F5 sce_paf_private_report_memblk
 0x9E289062 _f_ceilf
 0x07168A83 SjisZen2Han
@@ -1293,12 +1293,12 @@
 0x58AB86D8 sceNpGetSubjectStatus
 0xEB3DC670 UTF8toSJIS
 0x6319EDA3 cellImeJpAllDeleteConvertString
-0x9BC97762 _ZN11PSJSContextC1ERKS_
+0x9BC97762 PSJSContext::PSJSContext(PSJSContext const&)
 0x0A862772 cellGcmSetQueueHandler
 0xED30F1FA cellAtracMultiGetSecondBufferInfo
 0xD6551CD1 sceNpClansDestroyRequest
 0x7B56DC3F cellDmuxEnableEs
-0xC1A00166 _ZN3paf7PhXmBar13GetListWidgetEi
+0xC1A00166 paf::PhXmBar::GetListWidget(int)
 0x604D3131 NP_GetValue
 0x8C2BB498 sys_spinlock_initialize
 0x0F7B3B6D cellUsbPspcmEnd
@@ -1308,21 +1308,21 @@
 0xE394A3BD cellM4hdEncGetAuInfo
 0x5B684DFB UCS2toBIG5
 0x0D3C22CE cellRescSetWaitFlip
-0xB1A2076D _ZN4vec2aSERK4vec4
-0x9CB87B0D _ZN3vsh13MessageDialog12GetBasePlaneEv
+0xB1A2076D vec2::operator= (vec4 const&)
+0x9CB87B0D vsh::MessageDialog::GetBasePlane()
 0x69C27C12 fopen
 0xC6533FB2 divxDecClose
 0x007854F4 _FDclass
-0xF733525E _ZN3vsh11ContentInfo4ShowEff
+0xF733525E vsh::ContentInfo::Show(float, float)
 0x8FD2F1CC sceNpUpdateClockClean
-0x1EE13E83 _ZNSt6locale5facetD0Ev
+0x1EE13E83 std::locale::facet::~facet()
 0x166DCC11 sceNpLookupNpId
 0xFACC5962 sceNpGetMyLanguages
 0xD7A617F5 cellWebBrowserConfigSetViewCondition2
 0x313F04AB raw_spu_read_char
-0xBFA7DC8D _ZN3paf7Surface10SetFeatureENS0_7FeatureEb
+0xBFA7DC8D paf::Surface::SetFeature(paf::Surface::Feature, bool)
 0x01CD9CFD sceNpCommerceGetChildProductSkuInfo
-0xE49B2FB7 _ZN12bXCeAttrList12GetAttributeEPci
+0xE49B2FB7 bXCeAttrList::GetAttribute(char*, int)
 0x0423E622 sceNpTusGetMultiSlotVariable
 0x0A4E2541 spu_thread_read_ldouble
 0xEC324C8F sceNpCommerce2GetContentRatingInfoFromGameProductInfo
@@ -1336,16 +1336,16 @@
 0xB82E6F27 cellM4vEncGetAuInfo
 0xFC68F277 sceNetXmppSetPresence
 0x2D677E0C cellCelp8EncQueryAttr
-0x5D37C301 _ZN13MmsMdAccessor20GetMmsRecordInstanceE18MmsDbMediaCategory15MmsMetadataType
+0x5D37C301 MmsMdAccessor::GetMmsRecordInstance(MmsDbMediaCategory, MmsMetadataType)
 0x0AA9D63F cellDtcpIpStartAuthentication
 0xF972C733 cellHttpCookieExportWithClientId
-0x0E9E8DA5 _ZN3vsh12GetString_NoEv
-0x5015B8D3 _ZSt7_FiopenPKwNSt5_IosbIiE9_OpenmodeEi
+0x0E9E8DA5 vsh::GetString_No()
+0x5015B8D3 std::_Fiopen(wchar_t const*, std::_Iosb<int>::_Openmode, int)
 0x9F730445 cellMcadptRegisterCallback
 0x225AED26 sceNpTusTerm
-0xBB904C88 _ZN10bXCeParser16SetResolveEntityEb
+0xBB904C88 bXCeParser::SetResolveEntity(bool)
 0x32B741DE cellKbConfigEnd
-0xC7D0EE0C _ZNKSt8time_getIwSt19istreambuf_iteratorIwSt11char_traitsIwEEE16do_get_monthnameES3_S3_RSt8ios_baseRNSt5_IosbIiE8_IostateEPSt2tm
+0xC7D0EE0C std::time_get<wchar_t, std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>>::do_get_monthname(std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>, std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>, std::ios_base&, std::_Iosb<int>::_Iostate&, std::tm*) const
 0xBF607EC6 sceNpBasicGetClanMessageEntryCount
 0x858A930B inet_ntoa
 0x917D6E9B FT_Set_Renderer
@@ -1355,17 +1355,17 @@
 0xC9C3EF14 cellPrintLoadAsync
 0x86532174 imaxdiv
 0xB85E0B0D cellHidGetOwnership
-0x2CBA5A33 _ZN3paf9PhHandler11KillTimerCBEi
+0x2CBA5A33 paf::PhHandler::KillTimerCB(int)
 0xABC3CD2C cellStorageDataExport
-0xFE8F1361 _ZN3paf5PhWeb8JumpPageEPKw
+0xFE8F1361 paf::PhWeb::JumpPage(wchar_t const*)
 0xFE37A7F4 sceNpManagerGetNpId
 0xB5996784 sceNpMatching2GrantRoomOwnerVsh
-0xF85C926D _ZN3vsh3fim24getLocalAccountByCharPtrEv
+0xF85C926D vsh::fim::getLocalAccountByCharPtr()
 0x35A6846C cellPngDecGettIME
 0x1FDB3EC2 sceNpLookupUserProfileWithAvatarSizeAsync
 0xD0B1D189 cellGcmSetTile
 0xEF9D42D5 cellGameGetSizeKB
-0xAA8860B9 _ZN3paf11SurfaceBase18ConvertPixelFormatE9ImageMode
+0xAA8860B9 paf::SurfaceBase::ConvertPixelFormat(ImageMode)
 0x48D462A9 _FDint
 0x86CAE679 cellSailFeederVideoNotifySessionError
 0x761CB9BE cellAtracDeleteDecoder
@@ -1377,7 +1377,7 @@
 0xBC7B4B8E ctime
 0xD4F37B9D tanhf
 0x9F3D573E pafGuDepthFunc
-0xC03F89E6 _ZN3paf8PhWidget8GetStyleEiiR4mat4
+0xC03F89E6 paf::PhWidget::GetStyle(int, int, mat4&)
 0x1466611F cellNetCtlMintXGetState
 0xAC328493 FT_Done_GlyphSlot
 0xBC9A0086 module_start
@@ -1390,32 +1390,32 @@
 0xEC7DE355 _SceAdecCorrectPtsValue_mpmc
 0xC343EE10 cellSpursGetJobQueueId
 0xC82191E3 _sce_net_flush_route
-0xE667985A _ZNSt8time_putIcSt19ostreambuf_iteratorIcSt11char_traitsIcEEED0Ev
+0xE667985A std::time_put<char, std::ostreambuf_iterator<char, std::char_traits<char>>>::~time_put()
 0x17932B26 cellSailPlayerInitialize
-0x9F58ADCF _ZN3paf9CallQueue5CheckEv
-0xEF62751C _ZNKSt8time_getIcSt19istreambuf_iteratorIcSt11char_traitsIcEEE13do_date_orderEv
+0x9F58ADCF paf::CallQueue::Check()
+0xEF62751C std::time_get<char, std::istreambuf_iterator<char, std::char_traits<char>>>::do_date_order() const
 0xDFFB4E3C casinl
 0x28724522 UTF8toUCS2
 0xEED6C265 smf_ApRc_AddMetaData
 0x8F96319E log10l
-0xB94B439F _ZN3paf8PhXmList16SetTopLabelAlphaEfff
+0xB94B439F paf::PhXmList::SetTopLabelAlpha(float, float, float)
 0x52AAC4FA cellSaveDataUserAutoSave
-0xDFE2B134 _ZN3paf4Cond9NotifyAllEv
+0xDFE2B134 paf::Cond::NotifyAll()
 0x8F7AEA15 FTFaceH_GetRenderBufferSize
 0xDC54886C UCS2stoEUCKRs
-0x281F9107 _ZTv0_n12_NSiD1Ev
+0x281F9107 virtual thunk to std::basic_istream<char, std::char_traits<char>>::~basic_istream()
 0x64E1269D cellGcmSetVertexDataArray
 0x50239384 File_AllocLoad
 0x1E930EEF cellVideoOutGetDeviceInfo
-0x925494CB _ZN3paf8PhXmItem7FocusInEff
+0x925494CB paf::PhXmItem::FocusIn(float, float)
 0x24B26C3F sceNpMatchingLeaveRoomVsh
 0x7663E368 cellAudioOutGetDeviceInfo
-0x4761783A _ZNSt13basic_filebufIcSt11char_traitsIcEE5imbueERKSt6locale
+0x4761783A std::basic_filebuf<char, std::char_traits<char>>::imbue(std::locale const&)
 0x32F5CAE2 cellHttpDestroyTransaction
 0xA1F9EAFE _sys_sprintf
-0x128CD621 _ZNKSt5ctypeIwE10do_scan_isEsPKwS2_
-0xF72BABD5 _ZN3paf7PhSText12SetFontStyleERKNS_11PhFontStyleE
-0xB83F9AC8 _ZN13bXCeUTF8Utils13GetHexIntegerEPiPcj
+0x128CD621 std::ctype<wchar_t>::do_scan_is(short, wchar_t const*, wchar_t const*) const
+0xF72BABD5 paf::PhSText::SetFontStyle(paf::PhFontStyle const&)
+0xB83F9AC8 bXCeUTF8Utils::GetHexInteger(int*, char*, unsigned int)
 0x748BEDA3 cellRtcGetTickResolution
 0x7603D3DB cellMsgDialogOpen2
 0xA1468D7B svc1dGetAuxData
@@ -1423,7 +1423,7 @@
 0x893A7450 naacEncClear
 0x296BC72F _FDunscale
 0x4644B39A cellAvchatJpgDecGetDecodeStatus
-0x7A180518 _ZNSt10money_baseD0Ev
+0x7A180518 std::money_base::~money_base()
 0xC41E1198 cellPngDecGetsCAL
 0xF23F7052 smf_ApRc_SetMpeg4ESDesByParam
 0xFBFD0205 sceLoginServiceLocalLogin
@@ -1432,14 +1432,14 @@
 0x344E1CEB pafGuTexImage2
 0xEE303936 _Dsign
 0xA9E6103E sceNpMatching2RegisterSignalingCallback
-0x20F7E066 _ZNSt10moneypunctIwLb0EED0Ev
+0x20F7E066 std::moneypunct<wchar_t, false>::~moneypunct()
 0x34CE82A0 sceNpSignalingGetConnectionFromPeerAddress
 0xDD37DEB3 sceNpMatching2Term2Vsh
 0xC984BF53 roundf
 0x5091D738 Zi8SetDFAthreadCount
 0x37F514E1 cellGcmTransferLocation
 0x8ED310E5 cellSysutilAvcExtGetWindowRotation
-0x85BAAAA8 _ZN3paf7PhXmBar8IconMoveERK4vec4ffbiii
+0x85BAAAA8 paf::PhXmBar::IconMove(vec4 const&, float, float, bool, int, int, int)
 0xC4843B74 _cellSpursJobQueuePushJobBody
 0x00FB4A6B spu_thread_sprintf
 0x1F9BCBE6 ft_validator_error
@@ -1447,30 +1447,30 @@
 0x19A2ABEC CEComInitialize
 0x1827E724 FT_List_Up
 0x6995F5E8 _Ldtob
-0x849CCA15 _ZN3paf7SurfaceC1Eii9ImageMode10ImageOrderbiPvii
+0x849CCA15 paf::Surface::Surface(int, int, ImageMode, ImageOrder, bool, int, void*, int, int)
 0x950D53C1 cellSailPlayerCancel
 0x6FA37EA0 FT_Stream_TryRead
 0x74FE4A7B iswgraph
 0xEE5B20D9 sceNpScoreAbortTransaction
-0x0D219671 _ZN4cell5Daisy21LFQueue2GetPopPointerEPNS0_8LFQueue2EPij
-0x1B6AD260 _ZSt13resetiosflagsNSt5_IosbIiE9_FmtflagsE
+0x0D219671 cell::Daisy::LFQueue2GetPopPointer(cell::Daisy::LFQueue2*, int*, unsigned int)
+0x1B6AD260 std::resetiosflags(std::_Iosb<int>::_Fmtflags)
 0x0CBDAE68 sinf
 0xEAB40886 mvcDecRlsFrame
 0xF9884100 sceNpC7yTusInitVsh
-0x48B3774F _Z27_sce_np_sysutil_recv_packetiRN4cxml8DocumentERNS_7ElementE
+0x48B3774F _sce_np_sysutil_recv_packet(int, cxml::Document&, cxml::Element&)
 0x48D3EEAC cellRudpTerminate
 0x95DFECB1 _FCsubcc
 0xD40F3F2C erff
-0x4FCA79A3 _ZN4xMMS14CancelGenerateEj
+0x4FCA79A3 xMMS::CancelGenerate(unsigned int)
 0xD5506A07 cellGcmSetTextureAddressAnisoBias
 0xD830062A sys_dbg_signal_to_coredump_handler
-0xA5B4FB55 _ZN3paf9FrameworkC1ERKNS0_9InitParamE
-0x9268D6E7 _ZNKSt7num_getIwSt19istreambuf_iteratorIwSt11char_traitsIwEEE6do_getES3_S3_RSt8ios_baseRNSt5_IosbIiE8_IostateERj
+0xA5B4FB55 paf::Framework::Framework(paf::Framework::InitParam const&)
+0x9268D6E7 std::num_get<wchar_t, std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>>::do_get(std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>, std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>, std::ios_base&, std::_Iosb<int>::_Iostate&, unsigned int&) const
 0x8BB8A16A FTFaceH_GetRenderScale
-0x8A665143 _ZNSt8_Locinfo8_AddcatsEiPKc
+0x8A665143 std::_Locinfo::_Addcats(int, char const*)
 0xC414FAA5 cellMicReadDsp
 0xEA21EE28 sceNpUtilBuildTitleId
-0x1784C14A _Z39xcbUpdateProgressAddFinishedCurrentSizePvx
+0x1784C14A xcbUpdateProgressAddFinishedCurrentSize(void*, long long)
 0xB4225825 mbsinit
 0x5175ABB9 sceNpTusGetDataAsync
 0x61146857 smf_ApPs_ReadMovieRes_M
@@ -1481,16 +1481,16 @@
 0x55870804 _cellFiberPpuInitialize
 0xA165DAAE cellFontGetRenderScalePoint
 0x02F5CED0 cellCameraStop
-0x709AB035 _ZNSt15basic_streambufIcSt11char_traitsIcEE6setbufEPci
+0x709AB035 std::basic_streambuf<char, std::char_traits<char>>::setbuf(char*, int)
 0xF00CAD11 pafGuFrameCount
-0x828A7BA3 _ZN7bXCeDoc10InitializeEb
-0x8643AB81 _Z14xcbGetProgressPvP29_xCB_ContentOperationProgress
+0x828A7BA3 bXCeDoc::Initialize(bool)
+0x8643AB81 xcbGetProgress(void*, _xCB_ContentOperationProgress*)
 0xB42C66DF cellAsfGetFrameData
-0x41054F69 _ZN3paf11HalfImageL8EPvPKviiii
-0x51D70976 _ZNK3paf8PhWidget10GetTextureERNS_12SurfaceRCPtrINS_7SurfaceEEEi
+0x41054F69 paf::HalfImageL8(void*, void const*, int, int, int, int)
+0x51D70976 paf::PhWidget::GetTexture(paf::SurfaceRCPtr<paf::Surface>&, int) const
 0x78D05E08 cellFontSetupRenderEffectSlant
 0xAA7912B5 sceNpClansKickMember
-0xA37C3E51 _ZNKSt5ctypeIwE8do_widenEc
+0xA37C3E51 std::ctype<wchar_t>::do_widen(char) const
 0x4D6EDF71 sceAdFlushReportsPrepare
 0xB7D3427F iscntrl_ascii
 0xCCB06176 cellMgVideoDisconnect
@@ -1506,7 +1506,7 @@
 0x15419000 cellFsUtilitySetupHddAllForPs3
 0x32DA1344 smvd2GetAuxData
 0x9CAB08D1 spu_thread_write_int
-0x2F29DA90 _ZNSt12strstreambuf5_TidyEv
+0x2F29DA90 std::strstreambuf::_Tidy()
 0xA0ED322E cellUsbdGetFrameNumber
 0xA8A6F615 TlsSetValue
 0x5D4431F0 cellMediatorFlushCache
@@ -1517,13 +1517,13 @@
 0xA47C09FF cellGcmSetFlipStatus
 0x4B6A4010 vswprintf
 0x95CAE771 cellGifDecExtSetParameter
-0x29206AE0 _ZNK3paf10PhSaveData11GetSaveDataERNS_13SaveDataRCPtrINS_16SaveDataResourceEEE
+0x29206AE0 paf::PhSaveData::GetSaveData(paf::SaveDataRCPtr<paf::SaveDataResource>&) const
 0x8E5CFE9F sceNpMatching2GetServerIdListLocal
 0x25829BFD sceNetXmppRequestRoster
-0x907A4C6F _ZN3paf10PhItemSpin11UpdateStateEv
+0x907A4C6F paf::PhItemSpin::UpdateState()
 0x178D98DD atanf4fast
 0x6CFADA83 cellFontSetFontOpenMode
-0x55B3EBF2 _ZNSt9strstreamC2EPciNSt5_IosbIiE9_OpenmodeE
+0x55B3EBF2 std::strstream::strstream(char*, int, std::_Iosb<int>::_Openmode)
 0xC05545FD sceNpSnsFbTerm
 0x481557D4 sceNpMatching2RegisterLobbyEventCallbackVsh
 0x0829A21D asinhl
@@ -1532,49 +1532,49 @@
 0x4A0049C6 _Getpctype
 0x55E425C3 cellVideoOutGetConvertCursorColorInfo
 0xC79173FF cellHttpCookieExport
-0x0F930FDD _ZNSt13messages_baseD2Ev
-0xAF58E756 _ZN3paf9Framework8InstanceEv
+0x0F930FDD std::messages_base::~messages_base()
+0xAF58E756 paf::Framework::Instance()
 0x18319AC5 Zi8ConvertWC2UC
 0x90E392CF _cellSpursJobQueuePortPushJobBody2
 0xE2F1D4B2 tanh
 0x6D85F9B8 sceNetXmppRequestBlockList
 0x09CBEE1E strxfrm
 0x8D1D096C sceNpCommerceInitProductCategory
-0x42C40B2F _ZNSt12out_of_rangeD0Ev
+0x42C40B2F std::out_of_range::~out_of_range()
 0x738E40E6 cellSpursShutdownJobChain
 0xCA239640 fmodf4
-0x60DEE5B3 _ZN3vsh32SetButtonNavigationString_OptionEPKw
+0x60DEE5B3 vsh::SetButtonNavigationString_Option(wchar_t const*)
 0x99B38CE7 wmemmove
 0xFC663F7F sceNpSignalingGetPeerNetInfoResultVsh
 0xC5BC0FAC cellRtcParseDateTime
 0x406D1E1A FT_Matrix_Multiply
 0xEA99BEC1 cellM4vEncTermIntercommuner
-0x92F7E387 _ZN3paf4View8ActivateEv
+0x92F7E387 paf::View::Activate()
 0xAFFDADC0 cellSysutilAvcSetSpeakerVolumeLevel
-0x54E2C229 _ZN3paf9FrameworkD1Ev
+0x54E2C229 paf::Framework::~Framework()
 0xDF2ED367 cellSysutilAvc2GetVoiceMuting
 0x1C11885D _floorf4
-0x61A23009 _ZNKSt7num_putIwSt19ostreambuf_iteratorIwSt11char_traitsIwEEE5_FputES3_RSt8ios_basewPKcjjjj
+0x61A23009 std::num_put<wchar_t, std::ostreambuf_iterator<wchar_t, std::char_traits<wchar_t>>>::_Fput(std::ostreambuf_iterator<wchar_t, std::char_traits<wchar_t>>, std::ios_base&, wchar_t, char const*, unsigned int, unsigned int, unsigned int, unsigned int) const
 0x50B38E2B cellDivXDrmSetDrmMemoryName
-0x1167D7F4 _Z15mat4_from_scaleRK4vec4
+0x1167D7F4 mat4_from_scale(vec4 const&)
 0x77E08704 cellGemSetYaw
 0x89FB856E FT_Get_Sfnt_Table
 0x683FE299 cellSysutilAvcExtHidePanelEx
 0x701FD8A9 _cellSpursJobQueuePushSync
-0x83CBA890 _ZNSt6locale5facetD2Ev
+0x83CBA890 std::locale::facet::~facet()
 0x3D541975 atoi
 0xCC131B91 cellSysutilAvcExtStopMicDetection
-0xA7561A3F _ZN3paf5PhWeb6ReloadEv
+0xA7561A3F paf::PhWeb::Reload()
 0x3701F938 FT_Sin
 0x8B9D8DD2 iswpunct
 0x02E20EC1 __sys_printf_basename
 0x6BA4C668 sceNpMatching2ContextStartAsync
 0xC362273E epsonPrintSendBand
-0xDFD0D9A7 _ZN10bXCeXMLToD5ParseEPKcib
+0xDFD0D9A7 bXCeXMLToD::Parse(char const*, int, bool)
 0xF82E2EF7 cellHddGameGetSizeKB
 0x576831AE cellRudpGetRemoteInfo
 0xE3E379B8 _expf4fast
-0x566C9460 _ZN4cell5Daisy4Lock8popCloseEv
+0x566C9460 cell::Daisy::Lock::popClose()
 0x1C68CC75 uncompress
 0x63BFDB97 cellUsbdSetPrivateData
 0xFCFAF246 cellMicStop
@@ -1582,7 +1582,7 @@
 0xD632BCBF FTManager_Done_FreeType
 0x64AB4054 cellGcmSetFragmentProgramParameterPointer
 0xB6369393 _sys_heap_get_total_free_size
-0x4BC193C7 _ZNSt10ostrstreamC2EPciNSt5_IosbIiE9_OpenmodeE
+0x4BC193C7 std::ostrstream::ostrstream(char*, int, std::_Iosb<int>::_Openmode)
 0x1CA525A2 _sys_strncasecmp
 0x196DB98B cellSsSrtcSetRtc
 0x325392F7 cellGcmSetSurface
@@ -1592,28 +1592,28 @@
 0x09DE25FD cellSailPlayerIsEsAudioMuted
 0xC461563C cellMicCommand
 0x6377137F FTC_CMapCache_New
-0x246B55D0 _ZNK3paf9PhSRender12SetupTextureERKNS_12SurfaceRCPtrINS_7SurfaceEEE
+0x246B55D0 paf::PhSRender::SetupTexture(paf::SurfaceRCPtr<paf::Surface> const&) const
 0x246CA27F cellGcmSetVertexAttribInputMask
 0x1F953B9F recvfrom
 0x0A1D4B00 spu_thread_read_uint
 0x57E4DEC3 cellSpursRemoveWorkload
 0x5AB91391 sceNetCtlDisconnectVsh
-0x46CC88BE _ZN3paf6PhList15SetShadowRenderEPNS_9PhSRenderE
-0x62CB35B1 _ZN3paf12MiconPointee7ReleaseEv
+0x46CC88BE paf::PhList::SetShadowRender(paf::PhSRender*)
+0x62CB35B1 paf::MiconPointee::Release()
 0x676E3E7A raw_spu_write_ptr
-0x66FCC6F4 _ZNSt8messagesIwE7_GetcatEPPKNSt6locale5facetE
+0x66FCC6F4 std::messages<wchar_t>::_Getcat(std::locale::facet const**)
 0x10298371 cellSailAviMovieGetHeader
 0x18484DC6 FT_Stroker_Export
 0x2DA9FD9D cellFontGetRenderCharGlyphMetrics
-0x84484D13 _ZN4vec2C1Ef
-0xA74FFFC9 _ZN3paf8PhXmList13SetLabelAlphaEfff
+0x84484D13 vec2::vec2(float)
+0xA74FFFC9 paf::PhXmList::SetLabelAlpha(float, float, float)
 0xBB761C89 remquof
 0x69B373BF sceNetXmppRegisterBasicNotificationHandler
 0xAD1C6F02 cellHttpTransactionGetSslVersion
-0x6C5A6746 _ZNK3paf9PhNumSpin9IsInheritEPKc
-0xAD9051B6 _ZN3paf5SleepEi
+0x6C5A6746 paf::PhNumSpin::IsInherit(char const*) const
+0xAD9051B6 paf::Sleep(int)
 0xAACB0761 cellFt2dMean
-0xAEA59CEB _ZNSt10ctype_baseD0Ev
+0xAEA59CEB std::ctype_base::~ctype_base()
 0x3665864A Zi8AddUsedWordW_ZH
 0x14211FB9 sceNpMatchingDestroyCtxVsh
 0x17E3A76C cellM4vEncGetResult
@@ -1624,7 +1624,7 @@
 0xFF4BD923 cellAsfParser2AStdGetPacketInfo
 0x3CB818FA _f_fdimf
 0x3CE2E4F8 cellVdecSetPts
-0x3FDB44BB _Z9PSJS_Initv
+0x3FDB44BB PSJS_Init()
 0x2ED72466 cellGcmSetBackStencilMask
 0x9D30BDCE cellSailSourceInitialize
 0x2A6F33B5 cellM4hdEncEncodeFrame
@@ -1632,30 +1632,30 @@
 0x9034E538 cellSpursTaskGetContextSaveAreaSize
 0x486DAFF2 cellPostNrInitialize
 0x6D85DDB3 cellSubDisplayStop
-0x05A9CEF6 _ZNSt7_MpunctIcE5_InitERKSt8_Locinfo
+0x05A9CEF6 std::_Mpunct<char>::_Init(std::_Locinfo const&)
 0x6E565B59 FT_Request_Metrics
-0x0091A3FD _ZNKSt6locale9_GetfacetEj
+0x0091A3FD std::locale::_Getfacet(unsigned int) const
 0xE15939C3 cellFsChangeFileSizeByFdWithoutAllocation
 0x76FC8FB1 cellWebBrowserConfigSetHeapSize
 0x7028DEA9 _Locksyslock
 0xDC980E61 cellSsUmGetCacheOfFlashExtFlag
 0x9012A265 sceNpC7yLookupTssImageRequestVsh
-0xADC2263B _ZNSt15basic_streambufIcSt11char_traitsIcEE6xsputnEPKci
+0xADC2263B std::basic_streambuf<char, std::char_traits<char>>::xsputn(char const*, int)
 0x8CCF05ED sys_net_abort_resolver
 0xC01D9F97 printf
 0xB76E9937 FTRenderBuf_Adjust
 0x55C8A549 truncl
 0x98F0EEAB raw_spu_write_ulong
-0x8D81B2F3 _ZN3paf4CondD1Ev
+0x8D81B2F3 paf::Cond::~Cond()
 0x6298B55A cellImeJpEnterStringExt
 0x4AB22A63 _Caddcc
 0x16B3E5A4 sceNpMatching2CreateServerContext
 0xC9C536CE _ldexpf4
 0x4D878773 remainderf4
 0x61865281 cellMusicInitialize2SystemWorkload
-0x660882E8 _ZNSt6localeC1Ev
+0x660882E8 std::locale::locale()
 0xCC86A8F6 sceNpTusSetMultiSlotVariable
-0x3D841FE9 _Z5lerp4RK4vec4S1_f
+0x3D841FE9 lerp4(vec4 const&, vec4 const&, float)
 0xF82BBF7C cellMicSysShareEnd
 0xC2F85C09 cellMtpCancelRequest
 0x28CAD8B3 sceNpMatching2SendRoomMessage
@@ -1664,13 +1664,13 @@
 0xD83259E8 avcDecGetStatus
 0xD0BE74C1 cellGcmSetTransferReportData
 0x19731532 pafGuClearDepth
-0xCB7D484E _ZNK11PSJSContext10FindGlobalEPKc
+0xCB7D484E PSJSContext::FindGlobal(char const*) const
 0x63062249 cellSync2CondFinalize
 0x1AE10B92 _sys_spu_printf_attach_thread
 0x714ADCE1 log
 0xA789E631 cellSpursShutdownTaskset
 0x869E328D _SceAdecCorrectPtsValue_M4Aac2ch
-0x7797B150 _ZNK3paf7PhMicon13GetWidgetTypeEv
+0x7797B150 paf::PhMicon::GetWidgetType() const
 0x3AAAD464 cellPadGetInfo
 0xA77421C0 scePS1McHeader_GetTitleName
 0x91D287F6 cellSailPlayerSetEsAudioMuted
@@ -1679,40 +1679,40 @@
 0x736513CA cellApostSrcAdjustFirst
 0xBE48875F FT_Stream_OpenMemory
 0xAA1D1F57 cellImeJpBackspaceWord
-0xD59AEAD0 _ZN3vsh10OptionMenu7IsAliveEv
-0xAF168DD4 _ZN3vsh10ScrollText7SetTextERKSbIwSt11char_traitsIwESaIwEE
+0xD59AEAD0 vsh::OptionMenu::IsAlive()
+0xAF168DD4 vsh::ScrollText::SetText(std::basic_string<wchar_t, std::char_traits<wchar_t>, std::allocator<wchar_t>> const&)
 0xA0661626 cellMusicSetPlaybackCommand
 0xC5EC06C5 sceWaveAudioWriteBlockingEx
 0x4AEF2877 cellMusicDecodeFinalize2
 0xCB9C535B strftime
-0x5A93E4E8 _ZN4cell5Daisy22ScatterGatherInterlockD2Ev
+0x5A93E4E8 cell::Daisy::ScatterGatherInterlock::~ScatterGatherInterlock()
 0x129663D0 sceNpMatching2GetLobbyMemberDataInternal
 0x3B8097AC _WScanf
-0xFBAF2957 _ZN3paf7PhSText7SetTextERKSbIwSt11char_traitsIwESaIwEE
+0xFBAF2957 paf::PhSText::SetText(std::basic_string<wchar_t, std::char_traits<wchar_t>, std::allocator<wchar_t>> const&)
 0x48462FA1 cellAsfParser2InitParser
 0xC6C93D62 cellSysutilAvc2Load
 0xE0DA8EFD sys_spu_image_close
-0x18A38254 _ZNSt10ctype_baseD1Ev
+0x18A38254 std::ctype_base::~ctype_base()
 0xBB0AE221 sys_dbg_get_address_from_dabr
 0xB3A48079 cellFiberPpuContextFinalize
 0xBB0AA6D5 pafGuTexOffset
-0x002E18D8 _ZNSt6locale7_LocimpD0Ev
+0x002E18D8 std::locale::_Locimp::~_Locimp()
 0xD7DC3A8F strtod
-0x8E4FEF6E _ZNK3paf7PhMicon9IsInheritEPKc
+0x8E4FEF6E paf::PhMicon::IsInherit(char const*) const
 0xB0452730 sceSystemFileFree
-0x9D771C6F _ZN34xMMSMdStorageMediaGenerateProducer12EventHandlerEP7_xEventPv
+0x9D771C6F xMMSMdStorageMediaGenerateProducer::EventHandler(_xEvent*, void*)
 0xD0E3CBB0 FT_Stream_ReadChar
 0x50418A29 cellCryptoPuEccEcDh2
 0xD6A007B6 smf_FWrite
 0x1098A99D localeconv
-0x5CE195FA _ZN3vsh10OptionMenu4HideEv
+0x5CE195FA vsh::OptionMenu::Hide()
 0xE10183CE cellMouseEnd
-0x74093C9A _ZN3paf6PhText7AddAttrENS_14PhTextAttrTypeEjj
+0x74093C9A paf::PhText::AddAttr(paf::PhTextAttrType, unsigned int, unsigned int)
 0xB48636C4 sys_net_show_ifconfig
-0x4A75680B _ZN3paf7PhMicon5PauseEv
+0x4A75680B paf::PhMicon::Pause()
 0xDE9B7905 cellAtracMultiGetBufferInfoForResetting
 0x4D5836C8 sceNpMatching2AbortRequestVsh
-0x7902DF28 _ZN3paf13PhApplication21RegistUpdateDisplayCBEPFiiiiE
+0x7902DF28 paf::PhApplication::RegistUpdateDisplayCB(int (*)(int, int, int))
 0x450A4946 smf_FCancel
 0x5E8AAE6A svc1dCreateInstance2
 0x06BE743D cellFontGetKerning
@@ -1729,14 +1729,14 @@
 0x76AD182B PAF_Resource_ResolveRefNode
 0x8A264D71 cellSubDisplayGetPeerNum
 0xBE251A29 islower_ascii
-0x6F8663E4 _ZN3paf10MessageBox15SetProgressTextERKSbIwSt11char_traitsIwESaIwEEi
+0x6F8663E4 paf::MessageBox::SetProgressText(std::basic_string<wchar_t, std::char_traits<wchar_t>, std::allocator<wchar_t>> const&, int)
 0x9C246A91 xBDVDGetInstance
 0xFA6BCC17 cellAudioInUnregisterDevice
 0xC78DF618 rand_real3_TT800
 0x2E0A170D cellGemGetMemorySize
 0x0582338A cellSpursJobQueueAttributeSetDoBusyWaiting
 0x1A218FE4 cellFontRenderCharGlyphImageHorizontal
-0x711095A5 _ZN13bXCeXMLParser11SaveContextEv
+0x711095A5 bXCeXMLParser::SaveContext()
 0x7517724A cellSpursSetGlobalExceptionEventHandler
 0xD5AE37D8 cellVoiceSetVolume
 0xD76A16DA _fmaf4
@@ -1744,33 +1744,33 @@
 0x54F81789 cellRudpSetMaxSegmentSize
 0xDB23E867 cellGcmUnmapIoAddress
 0xB5573004 sceNpTrophyGetUserInfo
-0x76BBC067 _ZN3paf5Image10Rotation90Ei
+0x76BBC067 paf::Image::Rotation90(int)
 0x425FEF23 cellWebBrowserUpdatePointerDisplayPos2
 0x9FCB567B cellSpursGetTasksetInfo
 0x4AB1FA77 cellKbCnvRawCode
 0x01B84B27 llround
 0x474B7B13 sceNpMatchingJoinRoomGUI
-0x3286B855 _ZNSt8time_putIwSt19ostreambuf_iteratorIwSt11char_traitsIwEEE7_GetcatEPPKNSt6locale5facetE
+0x3286B855 std::time_put<wchar_t, std::ostreambuf_iterator<wchar_t, std::char_traits<wchar_t>>>::_Getcat(std::locale::facet const**)
 0x18B294D0 cellCameraResetAsync
 0x4EC1A446 cellGcmSetFragmentProgramGammaEnable
 0xE3BF9A28 sceNpTrophyCreateContext
 0x262A5AE2 UTF8stoGBKs
-0x3CAE2F8A _Z9normalizeRK4mat4
+0x3CAE2F8A normalize(mat4 const&)
 0x8D229F8E cellMicClose
 0xD4C19FDB FT_Sqrt32
-0xE7276F50 _ZN3vsh11ContentInfo4HomeEff
+0xE7276F50 vsh::ContentInfo::Home(float, float)
 0x3DCC2354 naacEncSetPCE
 0xA193143C cellSysmoduleSetMemcontainer
 0xF30142BB cellGcmTransferData
 0x1FCAEEBB FT_Outline_Decompose
-0x9DB21A04 _ZN3paf4View15SetEventHandlerEPKNS_18EventFunctionEntryE
+0x9DB21A04 paf::View::SetEventHandler(paf::EventFunctionEntry const*)
 0xB8474EFF _cellSpursTaskAttributeInitialize
 0x2F010BFA cellRtcTickAddMinutes
 0xE535B0D3 cellSailPlayerStart
 0x77A602DD free
 0xC63C354F _Exit
-0xE7D9F074 _ZNK4cxml7Element14GetNextSiblingEv
-0x207B56FA _ZNKSt7num_getIcSt19istreambuf_iteratorIcSt11char_traitsIcEEE8_GetffldEPcRS3_S6_RKSt6locale
+0xE7D9F074 cxml::Element::GetNextSibling() const
+0x207B56FA std::num_get<char, std::istreambuf_iterator<char, std::char_traits<char>>>::_Getffld(char*, std::istreambuf_iterator<char, std::char_traits<char>>&, std::istreambuf_iterator<char, std::char_traits<char>>&, std::locale const&) const
 0xE2DE89E6 csqrtf
 0x84D5E999 pafGuClearColor
 0x6001C52A pafGuTexMode
@@ -1789,14 +1789,14 @@
 0xCFFBE62C cellGcmInitFifo
 0xFF20157B cellSailRecorderGetParameter
 0x99B13034 cellRtcSetTick
-0x8341B529 _ZNSt13basic_filebufIwSt11char_traitsIwEE8overflowEi
+0x8341B529 std::basic_filebuf<wchar_t, std::char_traits<wchar_t>>::overflow(int)
 0xADC82D95 sceNpMatching2JoinRoomVsh
 0xE2E65CFC cellGemEnableMagnetometer2
 0xBBDFE4B7 cellGcmSetAlphaTestEnable
 0x0A7306A4 cellFontOpenFontFile
 0xE0A73B54 scePS2McIconSys_GetLightColor0
-0x27D4B92D _ZN3paf8PhXmList9HideItemsEff
-0x1B266C3D _ZNSt9money_getIcSt19istreambuf_iteratorIcSt11char_traitsIcEEE7_GetcatEPPKNSt6locale5facetE
+0x27D4B92D paf::PhXmList::HideItems(float, float)
+0x1B266C3D std::money_get<char, std::istreambuf_iterator<char, std::char_traits<char>>>::_Getcat(std::locale::facet const**)
 0x373523D4 cellSpursEventFlagWait
 0x66C6CC78 cellImeJpGetStatus
 0x5BFF9DA1 sceNpClansRemoveBlacklistEntry
@@ -1813,7 +1813,7 @@
 0x89BE28F2 cellAudioPortStart
 0x50AFFDC1 cellSailRecorderCreateProfile
 0x7994C28D _FDtentox
-0xFF99F7AB _ZN3paf7PhSText11RefreshTextEv
+0xFF99F7AB paf::PhSText::RefreshText()
 0x71DF362C sceNpC7yScoreEndVsh
 0xC90F4BBC _atan2f4
 0x3D85D6F8 strcmp
@@ -1821,7 +1821,7 @@
 0x72236EC1 cellSailMp4TrackGetTrackReferenceCount
 0xFB2081FD vfprintf
 0x7D967D91 cellSync2QueuePush
-0xB367A64E _ZN3paf9PhNumSpin12UpdateLayoutEb
+0xB367A64E paf::PhNumSpin::UpdateLayout(bool)
 0xE0CEE623 CEComUninitialize
 0x918A1BCB sceNpMatching2DestroyContextVsh
 0x24644561 cellWebBrowserWakeupWithGameExit
@@ -1844,23 +1844,23 @@
 0x32E56B1A _Stdin
 0x10627248 f_fmodf
 0x052D29A6 _sys_strcat
-0x00868264 _ZN3paf11SurfaceCLUTnwEj
-0x7C391411 _ZNSt10moneypunctIcLb0EED0Ev
-0x530D8265 _ZN3paf13PhApplication21DeleteUpdateDisplayCBEPFiiiiE
-0xB527E7E5 _ZN3paf8PhWidget17HandleAnalogEventEPNS_7PhEventE
+0x00868264 paf::SurfaceCLUT::operator new(unsigned int)
+0x7C391411 std::moneypunct<char, false>::~moneypunct()
+0x530D8265 paf::PhApplication::DeleteUpdateDisplayCB(int (*)(int, int, int))
+0xB527E7E5 paf::PhWidget::HandleAnalogEvent(paf::PhEvent*)
 0x677027AF cellSpursJobQueueSemaphoreInitialize
 0x5C8A9129 sceUpdateDownloadInitEx
 0x36D0C2C5 sceNpManagerGetAvatarUrl
 0x15D3C74C cellAvsetSetHDMIBhavior
 0xA82399B6 _cellAudioOutputBufferGetCommonInfo
 0x5E9253CA cellSslCertGetMd5Fingerprint
-0x01F81190 _ZNSt12codecvt_baseD1Ev
-0x9DF5EBC4 _ZN3paf8PhWidget17UpdateLayoutStyleEi
+0x01F81190 std::codecvt_base::~codecvt_base()
+0x9DF5EBC4 paf::PhWidget::UpdateLayoutStyle(int)
 0xB7B793ED get_state_TT800
 0xE4AC32CA sceNpMatching2GetRoomDataExternalList
-0xA8F64FDB _ZNKSt5ctypeIcE10do_tolowerEPcPKc
-0x739C8C04 _ZN3paf7PhXmBar8SetAlphaEfff
-0xBC8DD07D _ZN3paf7PhXmBar10ScrollLeftEfPNS_7PhEventE
+0xA8F64FDB std::ctype<char>::do_tolower(char*, char const*) const
+0x739C8C04 paf::PhXmBar::SetAlpha(float, float, float)
+0xBC8DD07D paf::PhXmBar::ScrollLeft(float, paf::PhEvent*)
 0xFF0A21B7 cellKbRead
 0x2D1B9F1A sceNpTusGetMultiUserDataStatusVUser
 0x6802DFB5 cellPrintGetStatus
@@ -1875,18 +1875,18 @@
 0xDA8FF8B8 sceNetHttpXmlSetServer
 0x59431D1B cellAtracMultiGetRemainFrame
 0xE5073959 SSL_read
-0x114E9178 _ZNSt11logic_errorD0Ev
+0x114E9178 std::logic_error::~logic_error()
 0x060EE3B2 JISstoUTF8s
 0x1576E4F2 cellMusicDecodeGetDecodeStatus2
 0xCBDC3A6D raw_spu_write_int
 0xC4248C51 cellApostSrcAdjustLast
-0x667D741B _ZNSt7num_putIwSt19ostreambuf_iteratorIwSt11char_traitsIwEEED0Ev
+0x667D741B std::num_put<wchar_t, std::ostreambuf_iterator<wchar_t, std::char_traits<wchar_t>>>::~num_put()
 0x8CD56EEE cellCameraSetAttribute
 0x3097CC1C cellUserInfoSelectUser_ListType
 0x4B6E8560 cellWebBrowserCreateRenderWithRect2
 0x186CB1FB cellMicIsOpen
-0xA700BC7D _ZNKSt7codecvtIwcSt9_MbstatetE6do_outERS0_PKwS4_RS4_PcS6_RS6_
-0x868C48A1 _ZN3paf9HalfImageEPvPKviiii
+0xA700BC7D std::codecvt<wchar_t, char, std::_Mbstatet>::do_out(std::_Mbstatet&, wchar_t const*, wchar_t const*, wchar_t const*&, char*, char*, char*&) const
+0x868C48A1 paf::HalfImage(void*, void const*, int, int, int, int)
 0x02EB41BB cellGemGetEnvironmentLightingColor
 0x2310F155 cellPngDecDecodeData
 0x92E4D899 cellRudpRead
@@ -1894,8 +1894,8 @@
 0xB1CC43E3 _CStrftime
 0x976CA5C2 cellJpgDecOpen
 0x7903400E cellMicSetNotifyEventQueue
-0x764CEAA4 _ZNSt10ostrstreamD0Ev
-0xD2649242 _ZN3paf8PhWidget8SetFocusEPNS_7PhEventEj
+0x764CEAA4 std::ostrstream::~ostrstream()
+0xD2649242 paf::PhWidget::SetFocus(paf::PhEvent*, unsigned int)
 0x58BE9A0F cellSync2CondInitialize
 0xEB81A467 cellSync2MutexInitialize
 0xB94B9D13 _Dtest
@@ -1904,19 +1904,19 @@
 0x5B18EDED clogl
 0x7C5A1812 cellFsUtilityGetFakeSize
 0x488DF791 cexp
-0x683C91D8 _ZN3paf8PhWidget6LookAtEPS0_RK4vec4S1_S4_
+0x683C91D8 paf::PhWidget::LookAt(paf::PhWidget*, vec4 const&, paf::PhWidget*, vec4 const&)
 0xFE1369A3 CEComSetMaxHeapSize
 0x31FC8B92 cellSysutilAvc2SetPlayerVoiceMuting
 0xED9143BF cellGcmSetDrawInlineIndexArray16Pointer
 0x9294B9DE sceNetHttpXmlAbortTransaction
 0xE9FFF717 smvd2GetNumPicture
-0xCFF699A0 _ZN3paf9CallQueue4PostEPFvPvES1_
-0x95B43C9D _ZNSt6locale7_LocimpD2Ev
+0xCFF699A0 paf::CallQueue::Post(void (*)(void*), void*)
+0x95B43C9D std::locale::_Locimp::~_Locimp()
 0x97C02090 sce_paf_private_dump_heap_info
 0x4AECEA24 cellMediatorGetSignatureLength
 0xF87BFE48 sceNpInstallerGetFacebookParam2
 0x06A553DF FT_Activate_Size
-0x87D90A81 _ZmiRK4vec4S1_
+0x87D90A81 operator- (vec4 const&, vec4 const&)
 0x1BB46A89 sceNetHttpXmlDeleteClient
 0x8D34D33B cellGcmSetDrawInlineIndexArray32
 0x44796E5C strerror
@@ -1925,10 +1925,10 @@
 0x5D02B091 cellVideoPlayerGetAudioTrackNumber
 0xED993147 cellHttpRequestAddHeader
 0xF0645452 _sys_net_lib_set_libnetctl_queue
-0x9BA36D14 _ZN3paf14GraphicsMemory4Area4FreeEPv
+0x9BA36D14 paf::GraphicsMemory::Area::Free(void*)
 0xB79B2FE0 sceNpGetNetworkTimeVsh
 0x2B127BAD cellGcmSetInlineTransferPointer
-0xE21C3432 _ZN3vsh10OptionMenu11GetMenuListEiNS0_8ListTypeE
+0xE21C3432 vsh::OptionMenu::GetMenuList(int, vsh::OptionMenu::ListType)
 0x400B7E88 FTFaceH_GetGlyphMetrics
 0x01508F24 raw_spu_write_float
 0xBCC09FE7 sceNpBasicRegisterHandler
@@ -1939,28 +1939,28 @@
 0xC54AAD2A cellPesmEncryptSample2
 0xEEDE898C cellImeJpConfirmPrediction
 0x409AD939 sys_mmapper_free_memory
-0x4E34CF83 _ZNSbIwSt11char_traitsIwESaIwEE5_GrowEjb
+0x4E34CF83 std::basic_string<wchar_t, std::char_traits<wchar_t>, std::allocator<wchar_t>>::_Grow(unsigned int, bool)
 0x1758053C jis2sjis
 0xC2F62FF2 Zi8AttachUWD_ZH
 0xE7DD87E1 cellSpursGetTasksetId
 0x33A2DB76 cellGcmCgGetParameterReferenced
 0x964AB1E7 divxDecDecodeAu
-0xDEFE3230 _ZNSt8ios_baseD1Ev
+0xDEFE3230 std::ios_base::~ios_base()
 0x256B6861 UCS2toSBCS
-0x61119152 _ZNSt6locale5_InitEv
+0x61119152 std::locale::_Init()
 0x76DA0C84 ftruncate
 0x97F9FBE5 cellHttpUtilCopyHeader
 0x8D14D09B cellPhotoExportFromFileWithCopy
 0xBE2789CC FT_Stream_Close
-0xBAFCBA67 _ZN3paf9PhNumSpinC2EPNS_8PhWidgetEPNS_8PhAppearE
+0xBAFCBA67 paf::PhNumSpin::PhNumSpin(paf::PhWidget*, paf::PhAppear*)
 0xFA00D211 read
-0x7C3602B7 _ZN11PSJSContextD1Ev
+0x7C3602B7 PSJSContext::~PSJSContext()
 0x7772EB2B cellAtracResetPlayPosition
 0x21397818 _cellGcmSetFlipCommand
 0x9663A44B cellSearchGetContentInfoByContentId
 0xD0066B17 cellFiberPpuContextSwitch
 0xEF51375F sceLoginServiceAddCallback
-0xF1543F02 _ZNKSt8_Locinfo8_GetcollEv
+0xF1543F02 std::_Locinfo::_Getcoll() const
 0x5B3D1FF1 cellPngDecClose
 0x83668B8E cellWebBrowserConfig
 0x48BD97C7 sceNpTrophyAbortHandle
@@ -1971,7 +1971,7 @@
 0x76E73DB2 cellFsUtilityGetTotalForUser
 0x712D51D6 cellSysutilAvc2JoinChatRequest
 0x1F61B3FF cellGcmDumpGraphicsError
-0xD9D8AF82 _ZNSt15basic_streambufIwSt11char_traitsIwEE8overflowEi
+0xD9D8AF82 std::basic_streambuf<wchar_t, std::char_traits<wchar_t>>::overflow(int)
 0x8BEDEFA8 cellHttpGetCookie
 0xFC656EA9 sceNpMatchingGetRoomListVsh
 0x3175AF23 sceNpTusDeleteMultiSlotDataAsync
@@ -1981,27 +1981,27 @@
 0xAD17E787 _Dint
 0xD9EA5709 cellSysutilAvcHidePanel
 0x1E7A247A cellFiberPpuUtilWorkerControlRunFibers
-0x5333BDC9 _ZNKSt13runtime_error4whatEv
+0x5333BDC9 std::runtime_error::what() const
 0x2EA3061E cellRescExit
 0xE857A0CA cellFontRenderCharGlyphImageVertical
-0xD2DC1C89 _ZNK3paf7PhSText8GetStyleEiRi
-0x58FAD1C1 _ZNSt5ctypeIwE7_GetcatEPPKNSt6locale5facetE
+0xD2DC1C89 paf::PhSText::GetStyle(int, int&) const
+0x58FAD1C1 std::ctype<wchar_t>::_Getcat(std::locale::facet const**)
 0x10C81457 cellSailRecorderOpenStream
 0x8CA59B74 cellCryptoPuEccEcDh1
-0x26F18EDF _ZN3vsh15GetString_EnterEv
+0x26F18EDF vsh::GetString_Enter()
 0x6F5E8143 sceNpScoreCreateTransactionCtx
 0x9DA74BB6 FT_Load_Char
 0xD5BB8191 FT_New_GlyphSlot
 0x75327302 cellGcmCgGetInstructions
 0x75F14D18 cellSysutilAvcExtSetChatGroup
-0x54A7300E _ZN3paf8PhXmItem5ClearEb
+0x54A7300E paf::PhXmItem::Clear(bool)
 0x32CF311F sceNpScoreInit
 0x4C191088 cellSailDescriptorGetUri
 0x5CC71EEE raw_spu_write_ldouble
 0x9647570B sendto
 0x7A893AF1 _rsqrtf4
 0x161DA6A7 cellSpursJobChainGetError
-0xE9A06D0A _ZN3paf15CriticalSectionC1Ev
+0xE9A06D0A paf::CriticalSection::CriticalSection()
 0x1CB1138F GBKstoUCS2s
 0x596AB55C atanh
 0xA7978F59 cellJpgDecCreate
@@ -2015,7 +2015,7 @@
 0x6F90AAF9 cellFsUtilityGetFsInfo
 0xC1AD7CED cellRudpActivate
 0xD8A473A3 sceNpCommerce2InitGetCategoryContentsResult
-0xD3CDD694 _ZN4cxml8Document12RegisterFileEPKvjPNS_4FileE
+0xD3CDD694 cxml::Document::RegisterFile(void const*, unsigned int, cxml::File*)
 0x20586BC0 _QN4cell5Daisy22ScatterGatherInterlockC1EPVNS0_16_AtomicInterlockEjPjjh
 0xA5151B13 cellGcmSetFlipStatus2
 0x5F44F64F cellSailMp4TrackGetTrackReference
@@ -2029,31 +2029,31 @@
 0x61250988 catanl
 0x8713C859 link
 0x9F46F5A4 tgammaf
-0xA4AC8FF6 _ZN9PSJSValueaSERKS_
+0xA4AC8FF6 PSJSValue::operator= (PSJSValue const&)
 0xE8DEE79C cellWebBrowserDestroy2
-0x3C5C886D _ZN11PSJSContext22SetExecMonitorCallbackEjPFbbPvES0_
-0x06572127 _ZN4xMMS15AttachThumbnailERK23MmsThumbnailAttachParam
+0x3C5C886D PSJSContext::SetExecMonitorCallback(unsigned int, bool (*)(bool, void*), void*)
+0x06572127 xMMS::AttachThumbnail(MmsThumbnailAttachParam const&)
 0x157D30C5 cellPngDecCreate
 0x34C3DA27 smf_FOpen_M
 0x4595C42B wcsxfrm
 0xF798F5E3 sceNpCommerce2InitGetProductInfoResult
-0x0BCC1910 _ZNSt10ostrstreamD2Ev
+0x0BCC1910 std::ostrstream::~ostrstream()
 0xD9EA3457 cellPamfReaderGetNumberOfEp
 0x70B0E833 mblen
-0x3F7CB0BF _ZN3paf6Module12SetInterfaceEiPv
+0x3F7CB0BF paf::Module::SetInterface(int, void*)
 0x5AE841E5 cellSyncQueuePush
-0xBE04476B _ZN3paf10PhDrawTextENS_6PhFont9GlyphTypeERNS_12SurfaceRCPtrINS_7SurfaceEEEiiPKwjRKS0_PKNS_17PhTextLetterSpaceE
+0xBE04476B paf::PhDrawText(paf::PhFont::GlyphType, paf::SurfaceRCPtr<paf::Surface>&, int, int, wchar_t const*, unsigned int, paf::PhFont const&, paf::PhTextLetterSpace const*)
 0x8478A915 sceNpMatchingGetRoomMemberListLocalVsh
 0x9E2B935A FT_Get_Postscript_Name
 0x8EBEB176 msmw_LockLock
 0x7E60ADC6 cellVoiceSetBitRate
 0xBA5BEE48 cellSyncRwmTryWrite
 0xE1F85A80 cellGemEnd
-0x75DC9C2D _ZN3vsh30SetButtonNavigationString_BackEPKw
+0x75DC9C2D vsh::SetButtonNavigationString_Back(wchar_t const*)
 0x3C579B2B cellCryptoPuTdesEncKeySet
 0x52A6B523 sceNpManagerUnregisterCallback
 0xA65CE0F8 cellCameraResetPost
-0x28549FD0 _ZN3vsh21InfobarAnimation_OpenEPN3paf4ViewEPKcS4_RNS_28InfobarAnimationInstanceDataEi
+0x28549FD0 vsh::InfobarAnimation_Open(paf::View*, char const*, char const*, vsh::InfobarAnimationInstanceData&, int)
 0xE9A1BD84 sys_lwcond_signal_all
 0xA876C911 cellOvisInitializeOverlayTable
 0xD8721E2C SJISstoEUCJPs
@@ -2066,48 +2066,48 @@
 0x3DCEA4DF divx311DecGetPicture
 0x959C4441 _sys_net_lib_abort
 0xB27C8AE7 sys_prx_load_module_list
-0x96BC2578 _Znajj
+0x96BC2578 operator new[](unsigned int, unsigned int)
 0xC99EE313 sceNpUtilBandwidthTestAbort
 0xF0B1E399 sceNpScoreRecordScoreAsync
 0x855DA8C6 cellSailVideoConverterProcess
-0x515ED57B _ZN10bXCeMemMgrnwEj
+0x515ED57B bXCeMemMgr::operator new(unsigned int)
 0x19869469 CEComRealloc
-0x6929318D _ZNSs6assignERKSsjj
+0x6929318D std::basic_string<char, std::char_traits<char>, std::allocator<char>>::assign(std::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, unsigned int, unsigned int)
 0x1CAEC657 cellFsFGetBlockSize2
 0xFA502B9B ft_debug_init
 0x0CF2B78B cellJpgEncReset
-0x8DACB8D0 _ZN4cell5Daisy22ScatterGatherInterlockD1Ev
+0x8DACB8D0 cell::Daisy::ScatterGatherInterlock::~ScatterGatherInterlock()
 0xC22C79B5 cellSaveDataAutoLoad
 0xF5839C09 epsonPrintEndPage
 0xA30D4797 wcstoll
 0xF3B4B43E cellOskDialogSetInitialInputDevice
-0x6813FD25 _ZN13bXCeUTF8Utils14ResolveCharRefEiPPhPi
+0x6813FD25 bXCeUTF8Utils::ResolveCharRef(int, unsigned char**, int*)
 0x73A45CF8 cellKeySheapSemaphoreDelete
 0x50C2962C cellSsVtrmRetrieve2
 0x97BF0029 mios2_Client_SendAsyncWait
-0xDC7E61D3 _ZN3paf11SurfaceCLUT4CopyEPv
+0xDC7E61D3 paf::SurfaceCLUT::Copy(void*)
 0xE1BC7ADD _cellSyncLFQueuePopBody
 0x280E6BA5 FTFaceH_GetBoundingBoxMaxX
 0xE61F7EE9 sceNpMatchingSendRoomMessage
 0x90710B9D atx_init_encode_global_table
 0x5D87C513 cellCryptoPuSha256Transform
-0x12DE5772 _ZNKSt9money_getIcSt19istreambuf_iteratorIcSt11char_traitsIcEEE6do_getES3_S3_bRSt8ios_baseRNSt5_IosbIiE8_IostateERSs
+0x12DE5772 std::money_get<char, std::istreambuf_iterator<char, std::char_traits<char>>>::do_get(std::istreambuf_iterator<char, std::char_traits<char>>, std::istreambuf_iterator<char, std::char_traits<char>>, bool, std::ios_base&, std::_Iosb<int>::_Iostate&, std::basic_string<char, std::char_traits<char>, std::allocator<char>>&) const
 0x46E2924C _cellAudioOpenAdmin
 0x23654375 cellSailPlayerInitialize2
-0x459B404D _ZN3paf8PhXmList9ArrowMoveERK4vec4ffi
+0x459B404D paf::PhXmList::ArrowMove(vec4 const&, float, float, int)
 0x6BB4EF9D _cellSyncLFQueueGetPushPointer2
-0xD557F850 _ZN3paf8PhWidget9FindChildEPKci
+0xD557F850 paf::PhWidget::FindChild(char const*, int)
 0x5E06172D cellAvcEncEncodeFrame
-0xAA1D51F6 _ZN9PSJSValue7SetAttrERK8psjsnameRKS_
-0x1F7BE1C8 _ZN3vsh15RaiseFatalErrorENS_14FatalErrorTypeE
+0xAA1D51F6 PSJSValue::SetAttr(psjsname const&, PSJSValue const&)
+0x1F7BE1C8 vsh::RaiseFatalError(vsh::FatalErrorType)
 0x46E6C806 _SceAdecCorrectPtsValue_wma
 0x1F372697 sceNpMatching2LeaveRoom
 0x153DD546 cellGcmSetRenderEnable
 0x170829D3 sceNpMatchingGetRoomMemberList
-0x38162763 _ZN3paf8PhWidget8SetStyleEiif
+0x38162763 paf::PhWidget::SetStyle(int, int, float)
 0x974E50F6 sceNetCtlAddHandlerSysUtil
 0xD5ACC03B cellGcmSetDepthTestEnable
-0x113A515F _ZNKSt8messagesIcE7do_openERKSsRKSt6locale
+0x113A515F std::messages<char>::do_open(std::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, std::locale const&) const
 0x2E3CCB5E cellSailGraphicsAdapterSetPreferredFormat
 0x12DE4E46 _powf4
 0x7FD479FE cellSync2QueueTryPush
@@ -2121,8 +2121,8 @@
 0xE0ECBB45 cellRtcTickAddMonths
 0x5A99F569 sceLoginServiceGetNpStatus
 0x2F7F391F cellSailComposerGetEsUserParameter
-0x55921E70 _ZN3paf8PhXmItem12AnimIconPlayEf
-0xCBE74AD3 _ZNKSt8messagesIwE8do_closeEi
+0x55921E70 paf::PhXmItem::AnimIconPlay(float)
+0xCBE74AD3 std::messages<wchar_t>::do_close(int) const
 0x8325E02D cellMicInit
 0x239FFCC4 smf_ApRc_SetFileProfileInfo
 0x97896359 isspace
@@ -2130,48 +2130,48 @@
 0xA39FE9DC cellHttpEndCache
 0xE3CC73F3 puts
 0x4066EB75 smvd4Initialize
-0x8846BC65 _ZN3paf7PhXmBar9ShowLabelEiff
+0x8846BC65 paf::PhXmBar::ShowLabel(int, float, float)
 0x6D087930 cellWebBrowserEstimate2
-0xA5E3A555 _ZN3paf10PhSaveDataC1EPNS_8PhWidgetEPNS_8PhAppearEP12malloc_state
-0xA0BBEBEE _ZN8XMWIOCTLC1Ev
+0xA5E3A555 paf::PhSaveData::PhSaveData(paf::PhWidget*, paf::PhAppear*, malloc_state*)
+0xA0BBEBEE XMWIOCTL::XMWIOCTL()
 0x9110708A modfl
 0x6FC4C791 cellGemFilterState
 0xAEB2EC57 _sys_net_lib_usleep
 0x57B89164 cellFt2dExtCreate
-0x3B002423 _ZNK3paf11PhLabelText12GetTextWidthEv
+0x3B002423 paf::PhLabelText::GetTextWidth() const
 0xD1AD4570 _sys_heap_get_mallinfo
 0x354B1125 CEUThread_create
 0xB4338C59 cellDecPsnvideoCloseTrack
 0x7048396E carg
 0x9C8BE729 FT_Outline_Check
-0x023F6755 _ZmLR4vec4RKS_
+0x023F6755 operator*= (vec4&, vec4 const&)
 0x8A6830E7 abort
 0x586EBC8A divxDecFlushPicture
 0x2BFFF084 cellAtracGetStreamDataInfo
-0x68D2B06D _ZNK3paf6PhText15GetVisibleLinesEv
-0x190D4130 _ZN3paf8PhWidget11RegistChildEPS0_
+0x68D2B06D paf::PhText::GetVisibleLines() const
+0x190D4130 paf::PhWidget::RegistChild(paf::PhWidget*)
 0xDE7B1BBD cellTiffDecExtCreate
 0x7BF6E152 sceNpMatching2SendRoomChatMessage
 0x53E39DF3 cellOskDialogSetSeparateWindowOption
 0x006C4900 cellSslCertGetNameEntryInfo
 0x69040B9B logbf4
 0x1B6EEA7E _cellSpursJobQueuePortPushJobListBody
-0x6051C802 _ZNSt7codecvtIccSt9_MbstatetED0Ev
+0x6051C802 std::codecvt<char, char, std::_Mbstatet>::~codecvt()
 0x224E1610 cellHttpClientSetRecvTimeout
 0x7CC47DDC cellGcmSetPolygonOffset
-0xBE085CD4 _ZNK3paf7PhSText8GetStyleEiR4vec4
+0xBE085CD4 paf::PhSText::GetStyle(int, vec4&) const
 0xB17B79D0 isalpha
 0x64C63FD5 cellRtcTickAddWeeks
 0x44608862 cellImeJpOpen
 0x62854AA7 pafGuTexImage
-0x62DCA3E2 _ZN3paf10PhItemSpin8SetStyleEiif
+0x62DCA3E2 paf::PhItemSpin::SetStyle(int, int, float)
 0x5CD29270 UTF8stoEUCKRs
-0x57EF52F0 _ZNSt15basic_streambufIwSt11char_traitsIwEE7_UnlockEv
+0x57EF52F0 std::basic_streambuf<wchar_t, std::char_traits<wchar_t>>::_Unlock()
 0x350D454E sys_ppu_thread_get_id
 0xA4133486 gnpc_resp_get_child
 0xDC751B40 send
 0x9306D15B FTFaceH_GetRenderScalePixel
-0xC22CEBD8 _ZNSt8messagesIwED1Ev
+0xC22CEBD8 std::messages<wchar_t>::~messages()
 0x3B159B19 BIO_printf
 0x6EE04954 cellRudpNetReceived
 0x299CCC9B sceNpClansCancelMembershipRequest
@@ -2180,7 +2180,7 @@
 0xF5992EC8 cellImeJpSetInputCharType
 0x9C300489 cellSpursJobQueueSetExceptionEventHandler
 0x39ECE24F cellGcmSetAnisoSpread
-0x033C18F4 _ZNSt8time_getIcSt19istreambuf_iteratorIcSt11char_traitsIcEEED1Ev
+0x033C18F4 std::time_get<char, std::istreambuf_iterator<char, std::char_traits<char>>>::~time_get()
 0x5BFF31BF cellMusicSetSelectionContext
 0x946ECCA0 cellSailSourceNotifyReadCompleted
 0x1051D134 cellSpursAttributeEnableSpuPrintfIfAvailable
@@ -2189,8 +2189,8 @@
 0x88F8340B UCS2stoJISs
 0x4DD12D0C sceNpGetUserIcon
 0x22CA0929 cellSysutilAvcExtSetHideNamePlate
-0x7A52B303 _ZN13MmsMdAccessor24ReleaseMmsRecordInstanceEP11MmsDbRecord
-0xCC58846C _ZN3paf7PhPlaneC2EPNS_8PhWidgetEPNS_8PhAppearE
+0x7A52B303 MmsMdAccessor::ReleaseMmsRecordInstance(MmsDbRecord*)
+0xCC58846C paf::PhPlane::PhPlane(paf::PhWidget*, paf::PhAppear*)
 0x021D6C1F sceNpSnsFbStreamPublish
 0x7817EDF0 raw_spu_write_uint
 0xB84F5C81 cellMusicDecodeSetSelectionContext
@@ -2201,33 +2201,33 @@
 0x18B76C7D InputDevice_SetModifierKey
 0xDA67B37F UTF8stoSBCSs
 0xB3D98D59 _rand_real1_TT800
-0x873C6688 _ZN3paf7PhTimer12GetFrameTimeEv
-0x7B79D6AA _ZN4cell5Daisy4Lock9pushCloseEv
-0x7EBAD3F0 _ZNKSt9money_putIwSt19ostreambuf_iteratorIwSt11char_traitsIwEEE8_PutmfldES3_bRSt8ios_basewbSbIwS2_SaIwEE
+0x873C6688 paf::PhTimer::GetFrameTime()
+0x7B79D6AA cell::Daisy::Lock::pushClose()
+0x7EBAD3F0 std::money_put<wchar_t, std::ostreambuf_iterator<wchar_t, std::char_traits<wchar_t>>>::_Putmfld(std::ostreambuf_iterator<wchar_t, std::char_traits<wchar_t>>, bool, std::ios_base&, wchar_t, bool, std::basic_string<wchar_t, std::char_traits<wchar_t>, std::allocator<wchar_t>>) const
 0x3EB7807B gnpc_resp_get_integers
 0x6F325C2D CEComDetachThread
 0x073FA321 cellFontOpenFontsetOnMemory
 0x19256DC5 cellPngEncOpen
 0xAF89FDBD _Assert
 0xB477F06A cellGcmInit
-0x4AFF73CC _ZSt14_Debug_messagePKcS0_
-0x17C35CC9 _ZN4cell5Daisy4Lock7popOpenEv
-0xFEFD7D3A _ZNKSt7num_getIwSt19istreambuf_iteratorIwSt11char_traitsIwEEE6do_getES3_S3_RSt8ios_baseRNSt5_IosbIiE8_IostateERy
+0x4AFF73CC std::_Debug_message(char const*, char const*)
+0x17C35CC9 cell::Daisy::Lock::popOpen()
+0xFEFD7D3A std::num_get<wchar_t, std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>>::do_get(std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>, std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>, std::ios_base&, std::_Iosb<int>::_Iostate&, unsigned long long&) const
 0x46C3FB5A _cellSpursJobQueuePortCopyPushBody
-0x2E8654F8 _ZN4cell5Daisy4Lock10initializeEj
+0x2E8654F8 cell::Daisy::Lock::initialize(unsigned int)
 0xEC89A187 cellFontFTGetRevisionFlags
 0x3C1FF1E0 cellCameraStopAsync
-0xB5505299 _ZN3paf8PhWidget15ReorderChildrenEPKS0_S2_i
+0xB5505299 paf::PhWidget::ReorderChildren(paf::PhWidget const*, paf::PhWidget const*, int)
 0x8657C8F5 cellFontSetEffectSlant
 0x19BCE18C sceNpTusPollAsync
-0xD9A12C5E _ZNKSt5ctypeIcE10do_toupperEPcPKc
+0xD9A12C5E std::ctype<char>::do_toupper(char*, char const*) const
 0x0B4B62D5 cellGcmSetPrepareFlip
 0x44F05E73 _sys_net_lib_if_nametoindex
 0xCE6DC0F0 sceNpClansRemoveChallenge
 0x856FF5C0 sceNpClansGetMemberList
 0xC2D8CF95 cellRtcGetDayOfWeek
 0xA823836B ilogb
-0xDA1088CE _ZNSt6locale5facet7_IncrefEv
+0xDA1088CE std::locale::facet::_Incref()
 0xD127CD3E cellMicSysShareInit
 0xFBB4047A lroundf
 0xEF645654 sceNpCommerce2GetGameProductInfo
@@ -2235,10 +2235,10 @@
 0xD7D6272F cellSysutilAvc2HideScreen
 0xD42CC7B3 CEUThread_destroy
 0xE93B9B31 pafGuDisable
-0x64ED868E _ZSt9terminatev
+0x64ED868E std::terminate()
 0x3AF9CA99 cellDSEEQueryMemorySize
 0x780A18BB cellAtracMultiDeleteDecoder
-0x5C7F2CA4 _ZN29xMMSMdRelationResolveAccessor13GetFieldIdForEPKhPj
+0x5C7F2CA4 xMMSMdRelationResolveAccessor::GetFieldIdFor(unsigned char const*, unsigned int*)
 0x5420E419 sys_net_show_nameserver
 0x20E5286E pafGuClear
 0x041CC708 cellPamfReaderGetStreamIndex
@@ -2251,27 +2251,27 @@
 0x752F8585 cellSailPlayerGetDescriptorCount
 0xDAB029AA cellAudioAddData
 0x4189A367 remquo
-0xB5AB27F9 _ZN7bXUtilsD1Ev
-0xB340EFC4 _ZN11PSJSContext12SetExceptionERK9PSJSValue
+0xB5AB27F9 bXUtils::~bXUtils()
+0xB340EFC4 PSJSContext::SetException(PSJSValue const&)
 0xC3A991EE sceNpScoreGetRankingByNpIdPcId
 0xCA417336 cellDivXDrmHookMallocFunctions
 0x7FCFC915 cellOskDialogLoadAsync
-0x36362357 _ZN3paf5Sound6Output4MuteEj20xSettingAudioOutMute
+0x36362357 paf::Sound::Output::Mute(unsigned int, xSettingAudioOutMute)
 0x392C5AA5 cellFiberPpuUtilWorkerControlSetPollingMode
 0x833F4516 sceAdAsyncSpaceOpen
-0x565ABD7E _ZN3paf10PhSaveData11SetSaveDataERKNS_13SaveDataRCPtrINS_16SaveDataResourceEEE
-0x1D43FB44 _ZSt9use_facetISt8numpunctIwEERKT_RKSt6locale
+0x565ABD7E paf::PhSaveData::SetSaveData(paf::SaveDataRCPtr<paf::SaveDataResource> const&)
+0x1D43FB44 std::numpunct<wchar_t> const& std::use_facet<std::numpunct<wchar_t>>(std::locale const&)
 0x2D17CA7F _Puttxt
-0x638A0B38 _ZN3paf7PhSText8SetStyleEiRK4vec4
+0x638A0B38 paf::PhSText::SetStyle(int, vec4 const&)
 0xDF5553EF cellSailDescriptorClearEs
 0x86069C54 scePS1McHeader_IsPDA
 0xF042B14F sceNpDrmIsAvailable2
-0x6A784AE5 _ZN3vsh13MessageDialog15SetProgressTextERKSbIwSt11char_traitsIwESaIwEEi
+0x6A784AE5 vsh::MessageDialog::SetProgressText(std::basic_string<wchar_t, std::char_traits<wchar_t>, std::allocator<wchar_t>> const&, int)
 0x72F9C360 sceNetBase64Decoder
 0x384C65CF cellFsMappedFree
 0xCEEEBC7A sceNpProfileCallGui
-0xEFC3730F _Z9transposeRK4mat4
-0xCC03A4E5 _ZN12bXCeAttrList10InitializeEv
+0xEFC3730F transpose(mat4 const&)
+0xCC03A4E5 bXCeAttrList::Initialize()
 0x1CFA1A11 cellVideoOutSetXVColor
 0x1D2BCA4B cellSpursSendWorkloadSignal
 0x2DE80ABC sceNetCalloutStop
@@ -2286,32 +2286,32 @@
 0x437E1EB8 sjvtdReleasePicture
 0x52D9457A cellWebBrowserConfigSetFullVersion2
 0xECA938CA cellSysutilAvcSetAttribute
-0xF21655F3 _ZN3paf4View4FindEPKc
+0xF21655F3 paf::View::Find(char const*)
 0x036D6368 pafGuSwapStatus
 0x1A789B68 FT_Realloc
-0xD03F99CF _ZNK4cxml9Attribute13GetFloatArrayEPPKfPj
+0xD03F99CF cxml::Attribute::GetFloatArray(float const**, unsigned int*) const
 0xFDA12276 cellMicGetFormatAux
-0xE50657B1 _ZN3paf4View12SetLocaleAllE6Locale
+0xE50657B1 paf::View::SetLocaleAll(Locale)
 0x32D3AA9F _cellGcmSetFlipCommand2
-0xC923924A _ZN3paf5PhWeb13SetWindowSizeEii
-0xB8E256D7 _ZN3vsh13GetString_YesEv
+0xC923924A paf::PhWeb::SetWindowSize(int, int)
+0xB8E256D7 vsh::GetString_Yes()
 0x6B148570 cellCelpEncQueryAttr
 0xC4808FD7 cellRtcGetCurrentSecureTick
 0x13606E8A cellGcmSetVertexData4s
 0x67EB4153 smf_ApPs_GetAC3SpecificInfo
-0xBFF616B8 _ZN3paf7PhSPrim17UpdateMatrixColorEPKNS_8PhWidgetERK4vec4
+0xBFF616B8 paf::PhSPrim::UpdateMatrixColor(paf::PhWidget const*, vec4 const&)
 0x4D06AEF7 sceNpClansAddBlacklistEntry
 0xF2FCA4B2 spu_thread_write_llong
-0xB4D3C063 _Z16pafGumPushMatrixv
-0x934BC624 _ZN13PSJSValueImpl11NewFromPoolERK11PSJSContexti
+0xB4D3C063 pafGumPushMatrix()
+0x934BC624 PSJSValueImpl::NewFromPool(PSJSContext const&, int)
 0xC7CF1182 cellVoiceInit
-0x505FA917 _ZN8cxmlutil7GetFileERKN4cxml7ElementEPKcPNS0_4FileE
-0xD76B2E07 _ZNKSt7codecvtIwcSt9_MbstatetE13do_max_lengthEv
+0x505FA917 cxmlutil::GetFile(cxml::Element const&, char const*, cxml::File*)
+0xD76B2E07 std::codecvt<wchar_t, char, std::_Mbstatet>::do_max_length() const
 0x37B5BA0C cellSearchGetContentInfoPathMovieThumb
 0x98AC5524 cellFontGetFontIdCode
 0x4D0651A7 xRegistryGetValue
 0x3E359AB6 cellGameUpdateCheckAbort
-0x053D12C7 _ZN3paf6PhSpin22HandleFocusSwitchEventEPNS_7PhEventE
+0x053D12C7 paf::PhSpin::HandleFocusSwitchEvent(paf::PhEvent*)
 0xBF6F72CE cellGcmSetBackStencilOp
 0x1B67409D FTCacheStream_End
 0xD24E3928 cellGameThemeInstall
@@ -2320,57 +2320,57 @@
 0x0D69929E _cellSpursJobQueueAllocateJobDescriptorBody
 0x8D5858DB _f_exp2f
 0xC07896F9 cellGemPrepareVideoConvert
-0xBAFE871A _ZN3paf8PhCamera26SetVirtualScreenAdjustDistEff
+0xBAFE871A paf::PhCamera::SetVirtualScreenAdjustDist(float, float)
 0xEF110B6B unlink
 0x540B43AE smvd2ReleaseInstance
 0x75ECB783 smvd4CreateInstance2
 0x4D348427 fputs
-0xFFAF3218 _ZTv0_n12_NSoD0Ev
-0x8A6B3741 _ZN10PSJSObjectC2ERK11PSJSContext
+0xFFAF3218 virtual thunk to std::basic_ostream<char, std::char_traits<char>>::~basic_ostream()
+0x8A6B3741 PSJSObject::PSJSObject(PSJSContext const&)
 0x8F2BCDB5 _logf4
 0x943A6675 cellAvchatJpgDecOpenExt
 0x8B168769 fdiml
 0x0EBE4C6B sceNpMatching2SignalingGetConnectionStatus
-0xC93A60A8 _ZN10PSJSObject7DelAttrEi
+0xC93A60A8 PSJSObject::DelAttr(int)
 0xFD5B7C04 FT_Bitmap_Convert
 0x506AD863 inet_network
 0xE2B596EC ccosf
-0x31D9894A _ZNK10PSJSObject11ToPrimitiveE15ToPrimitiveHint
+0x31D9894A PSJSObject::ToPrimitive(ToPrimitiveHint) const
 0x1988732D clog10
 0xBCDBB2AB sceNpBasicAddPlayersHistoryAsync
 0x2A6D9D51 sys_lwcond_wait
 0x72632E53 SBCSstoUTF8s
-0x65F19631 _ZTv0_n12_NSiD0Ev
-0x73F85259 _ZN3vsh25ShowButtonNavigation_ViewEb
+0x65F19631 virtual thunk to std::basic_istream<char, std::char_traits<char>>::~basic_istream()
+0x73F85259 vsh::ShowButtonNavigation_View(bool)
 0x2880D8D5 sceNpAuthDeleteOAuthRequest
 0x9097FC9B cellHidUnregisterHotKeyObserver
 0xA7658186 log1pf4
-0xF4524A9C _ZNK3paf7PhMicon9GetHeightEv
+0xF4524A9C paf::PhMicon::GetHeight() const
 0x615369C3 FT_Vector_Length
-0xAB743FE4 _ZN3paf7PhMiconC1EPNS_8PhWidgetEPNS_8PhAppearEP12malloc_state
+0xAB743FE4 paf::PhMicon::PhMicon(paf::PhWidget*, paf::PhAppear*, malloc_state*)
 0x568A9D13 smf_ApPs_GetIPMPDesInfo
 0x82A3CC30 wcschr
 0xE8B1C18D cellSysutilAvcExtSetWindowZorder
 0x15DF71ED cellSysutilAvcLoadAsync
-0x15BBE128 _ZN3paf9PhNumSpin8GetStyleEiiR4vec4
+0x15BBE128 paf::PhNumSpin::GetStyle(int, int, vec4&)
 0x05AF1CB8 sceNpBasicGetMatchingInvitationEntry
-0x8729F617 _ZNSt10ostrstreamC1EPciNSt5_IosbIiE9_OpenmodeE
+0x8729F617 std::ostrstream::ostrstream(char*, int, std::_Iosb<int>::_Openmode)
 0xEDA86C48 copysignf4
 0xE1E7B5AC sceNpCommerce2GetProductInfoListCreateReq
 0x268EDD6D cellSyncBarrierTryNotify
 0xA328CC35 cellMouseGetRawData
-0x581FC95B _ZNSt5ctypeIcED0Ev
+0x581FC95B std::ctype<char>::~ctype()
 0x770BFAEE wctype
 0x30D3D12B cellSysutilGameReboot_I
 0x6A4B95C1 cellFsLsnRead
 0xCCC6E177 sceNpInitVsh
 0xFCE6D30A sceNpTrophyGetTrophyInfo
 0x227E1E3C cellFontSetupRenderScalePixel
-0x4992D5E8 _Z17xcbIsStorageMediaPvx
+0x4992D5E8 xcbIsStorageMedia(void*, long long)
 0x928AC5F8 cellGemTrackHues
 0xA5146299 UTF8stoARIBs
 0xF7261881 FT_Glyph_StrokeBorder
-0x00C3975E _ZNSt15basic_streambufIcSt11char_traitsIcEE5_LockEv
+0x00C3975E std::basic_streambuf<char, std::char_traits<char>>::_Lock()
 0x220894E3 cellSysutilEnableBgmPlayback
 0x21E9CF83 epsonPrintCancelPage
 0x3A12865F cellNetCtlGetNatInfo
@@ -2379,27 +2379,27 @@
 0xC4C600F3 R_time_cmp
 0xF06EED36 wmemset
 0xD763903D cellVideoPlayerGetSubtitleTrackNumber
-0x9DBBE07D _ZNKSt9money_getIcSt19istreambuf_iteratorIcSt11char_traitsIcEEE8_GetmfldERS3_S5_bRSt8ios_base
-0x56FAC416 _ZNKSt7num_getIwSt19istreambuf_iteratorIwSt11char_traitsIwEEE6do_getES3_S3_RSt8ios_baseRNSt5_IosbIiE8_IostateERe
+0x9DBBE07D std::money_get<char, std::istreambuf_iterator<char, std::char_traits<char>>>::_Getmfld(std::istreambuf_iterator<char, std::char_traits<char>>&, std::istreambuf_iterator<char, std::char_traits<char>>&, bool, std::ios_base&) const
+0x56FAC416 std::num_get<wchar_t, std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>>::do_get(std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>, std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>, std::ios_base&, std::_Iosb<int>::_Iostate&, long double&) const
 0xF9729831 cellGcmSetDrawInlineIndexArray32Pointer
-0x39592B83 _Z20xcbReferMetadataTypePvPPh
+0x39592B83 xcbReferMetadataType(void*, unsigned char**)
 0x7E4EA023 cellSpursWakeUp
 0x659E011E sqrt
-0xB24DE5AC _ZN3paf7PhXmBar16SetOtherTopAlphaEfff
+0xB24DE5AC paf::PhXmBar::SetOtherTopAlpha(float, float, float)
 0xB9BE30C0 cellM4vEncCancelAuInfo
 0xF0C7C488 cellVideoPlayerInitializeStereoVideo
-0x59A11C82 _ZN3paf9PhNumSpin10WidgetTypeEv
-0xEB793E25 _ZN3paf9PhSRender8SetStyleEib
-0x11498CDF _ZN3paf7PhMicon4StopEv
+0x59A11C82 paf::PhNumSpin::WidgetType()
+0xEB793E25 paf::PhSRender::SetStyle(int, bool)
+0x11498CDF paf::PhMicon::Stop()
 0x3E4A2075 sceNpTusGetFriendsDataStatusAsync
 0xB23E3BD1 sceNpCommerce2DoProductBrowseFinishAsync
 0x86C75EAE cellGcmSetVertexProgramLoad
-0xD4579440 _ZN3paf10PhSPrimDiv8SetStyleEif
+0xD4579440 paf::PhSPrimDiv::SetStyle(int, float)
 0x5AD46570 cellCameraEnd
 0xB2EC23EB PhiChangeResource
 0x1170A5EA _cellAudioSetAudioEventCallback_pathThrough
 0x9E19072B cellFontOpenFontMemory
-0x6E0BF85D _ZTv0_n12_NSt10istrstreamD1Ev
+0x6E0BF85D virtual thunk to std::istrstream::~istrstream()
 0x7508112E sceNpLookupPollAsync
 0x0C8CAE53 FT_Stroker_Done
 0xC2CED2B7 sceNpUtilBandwidthTestInitStart
@@ -2407,24 +2407,24 @@
 0xCCCE71BD cellRtcTickAddSeconds
 0x94671B4F SSL_CIPHER_get_version
 0x1533C6A9 cellVdecDecodeAuEx2
-0xD8C04EAE _ZN4xMMS17InsertMetadataSetEjPPvPy
+0xD8C04EAE xMMS::InsertMetadataSet(unsigned int, void**, unsigned long long*)
 0x7B96F1EE sqlite3_bind_text16
-0xDF031EDD _ZN3paf8PhWidget16UpdateLayoutSizeEv
+0xDF031EDD paf::PhWidget::UpdateLayoutSize()
 0x55C70783 cellPhotoInitialize
-0xDF27BD9B _ZN4vec3C1Efff
+0xDF27BD9B vec3::vec3(float, float, float)
 0xCD1DE92F sceNpMatchingInviteToRoomVsh
 0x2140F339 cellAvsetSetBackendMute
 0xA3DA58F6 rand_real1_TT800
-0x8462FA93 _ZNK10PSJSObject7GetAttrEiP9PSJSValue
+0x8462FA93 PSJSObject::GetAttr(int, PSJSValue*) const
 0x9E48E5DD SSL_shutdown
 0x20215547 inflate
-0x3848A5D4 _ZN4cxml8Document14CreateFromFileEPvb
+0x3848A5D4 cxml::Document::CreateFromFile(void*, bool)
 0xF1790E85 cellGcmCgGetTotalBinarySize
 0x3C8C827C cellSysutilAvc2SetWindowPosition
 0xDE2F9C85 sys_process_atexit
 0x4550C94C sceNpMatching2GetLobbyInfoListVsh
 0xB67050BC FT_GlyphLoader_CopyPoints
-0x41BBFE5E _ZN3paf7PhScene10WidgetTypeEv
+0x41BBFE5E paf::PhScene::WidgetType()
 0x405F9727 _log1pf4fast
 0x6C93EA18 cellSpursJobQueueSemaphoreAcquire
 0x9FC0AA39 Heap_ReAlloc
@@ -2435,7 +2435,7 @@
 0x44ECA8B4 sceNpTusDestroyTransactionCtx
 0xA9072DEE cellSyncMutexInitialize
 0xE5282470 FTFaceH_GetMaxHorizontalAdvance
-0x7A2DD431 _ZNK3paf7PhMicon9GetVolumeEv
+0x7A2DD431 paf::PhMicon::GetVolume() const
 0x99782342 strncasecmp_ascii
 0xDD508B56 sceNpSignalingCancelPeerNetInfoVsh
 0xD9F235F2 cellGcmSetFrequencyDividerOperation
@@ -2444,9 +2444,9 @@
 0x3459748B log10f4
 0x055BD74D cellGcmGetTiledPitchSize
 0xFC096B9E cellCryptoPuAesEncKeySet
-0x20A02B6D _ZNSt6locale2idcvjEv
-0x6F1945FC _ZNSoD1Ev
-0xAD12E5C9 _Z31_sce_np_sysutil_send_packet_subiRN4cxml8DocumentE
+0x20A02B6D std::locale::id::operator unsigned int()
+0x6F1945FC std::basic_ostream<char, std::char_traits<char>>::~basic_ostream()
+0xAD12E5C9 _sce_np_sysutil_send_packet_sub(int, cxml::Document&)
 0x17427A25 cellGcmSetWaitLabel
 0x55982D1E cellGcmSetStencilFunc
 0xA7BFF757 sceNpManagerGetStatus
@@ -2458,17 +2458,17 @@
 0xB9CF473D UTF8toSBCS
 0x34944F04 cellAsfParser2AStdGetNonStreamObjectInfo
 0xDEEFDFA7 cellKbSetReadMode
-0xF6A4706B _ZN13PSJSValueImpl11NewFromPoolERK11PSJSContext13PSJSValueType
+0xF6A4706B PSJSValueImpl::NewFromPool(PSJSContext const&, PSJSValueType)
 0xBF1DC25B cellVideoPlayerGetSubtitleTrackInfo
 0x55ACAB8A cellCryptoPuSha1Init
-0x040D12CE _ZN3paf6PhSpin18HandleKeycodeEventEPNS_7PhEventE
-0x3D41CC84 _ZN3paf10PhSaveData10SetBGColorEiRK4vec4
+0x040D12CE paf::PhSpin::HandleKeycodeEvent(paf::PhEvent*)
+0x3D41CC84 paf::PhSaveData::SetBGColor(int, vec4 const&)
 0xCE7A9E76 isprint_ascii
 0x18668CE3 exp
-0xB53FA02E _ZnwjjRKSt9nothrow_t
+0xB53FA02E operator new(unsigned int, unsigned int, std::nothrow_t const&)
 0x9003B1F2 cellHttpUtilEscapeUri
 0x2BAB7F9C smf_FSetValidSize
-0x724042E6 _ZpLR4vec4RKS_
+0x724042E6 operator+= (vec4&, vec4 const&)
 0x04DD4855 FT_Outline_Get_Orientation
 0x8EB0E65F cellAtracDecode
 0xECD37366 sceNetApCtlInitVsh
@@ -2478,61 +2478,61 @@
 0x1917359D _cellSpursJobQueuePortCopyPushJobBody
 0x4BBC14E6 FT_Stroker_CubicTo
 0x0F624540 kuten2eucjp
-0xB9E387DD _ZN3paf10PhItemSpin12UpdateLayoutEb
+0xB9E387DD paf::PhItemSpin::UpdateLayout(bool)
 0x2F457571 cellVideoExportInitialize2
 0x7AA1AA12 cellJpgEncCoreCreate
 0xDAA5CD20 cellGameSetParamString
 0x2F256B29 sys_rsxaudio_import_shared_memory
 0x98947A6E cellMusicSetPlaybackCommand2
-0xC862F7C8 _ZNSt12strstreambuf8overflowEi
+0xC862F7C8 std::strstreambuf::overflow(int)
 0xC3476D0C sys_lwmutex_destroy
-0x9D3984DF _ZN4xMMS11GetInstanceEv
+0x9D3984DF xMMS::GetInstance()
 0x67F9FEDB sys_game_process_exitspawn2
 0x37345541 log1pl
 0x42770196 Zi8AttachOEMdata
-0x2CE5FF1D _ZN3paf8PhWidget11SetDispatchEj
-0x040C18FF _ZNKSt7_MpunctIwE16do_decimal_pointEv
+0x2CE5FF1D paf::PhWidget::SetDispatch(unsigned int)
+0x040C18FF std::_Mpunct<wchar_t>::do_decimal_point() const
 0x9768B6D3 UTF32toUTF8
 0xC01B4E7C cellAudioOutGetSoundAvailability
 0x06EDEA9E cellGcmSetUserHandler
-0xE8129023 _ZN3paf8PhWidget8SetStyleEiiRK4vec4
-0x1C8405DC _ZNSt7_MpunctIcEC2Ejb
+0xE8129023 paf::PhWidget::SetStyle(int, int, vec4 const&)
+0x1C8405DC std::_Mpunct<char>::_Mpunct(unsigned int, bool)
 0x1E0870D1 sceNpTssGetDataAsync
 0x35D84910 cellVoiceSetNotifyEventQueue
 0xE01B199E cellFontGlyphRenderImage
-0x62ED555B _ZN3paf7PhXmBar8ShowFadeEff
-0xCE6705C3 _ZNKSt7num_getIwSt19istreambuf_iteratorIwSt11char_traitsIwEEE8_GetifldEPcRS3_S6_NSt5_IosbIiE9_FmtflagsERKSt6locale
+0x62ED555B paf::PhXmBar::ShowFade(float, float)
+0xCE6705C3 std::num_get<wchar_t, std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>>::_Getifld(char*, std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>&, std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>&, std::_Iosb<int>::_Fmtflags, std::locale const&) const
 0x3F59F7B6 sceNpC7yScoreAbortVsh
 0x59106229 sceUpdateDownloadSetUrl
-0x5046CFAB _ZN3vsh20ApplyCooperationModeEv
+0x5046CFAB vsh::ApplyCooperationMode()
 0x8587A3C2 sceNpMatchingCreateRoomVsh
 0x6CF78F3E _Mtxunlock
 0x8EFD6C85 cellAvcEncSmallCancelLocalDecodedFrame
-0x6437A975 _ZNKSt7num_getIcSt19istreambuf_iteratorIcSt11char_traitsIcEEE6do_getES3_S3_RSt8ios_baseRNSt5_IosbIiE8_IostateERt
+0x6437A975 std::num_get<char, std::istreambuf_iterator<char, std::char_traits<char>>>::do_get(std::istreambuf_iterator<char, std::char_traits<char>>, std::istreambuf_iterator<char, std::char_traits<char>>, std::ios_base&, std::_Iosb<int>::_Iostate&, unsigned short&) const
 0x9FAE7F38 CEComDebugPrintf
 0xDEB0D2E6 _QN4cell5Daisy22ScatterGatherInterlock5probeEj
 0x70625CDB sqlite3_column_blob
 0x8EF85E47 _WPuttxt
 0x595ADEE9 cellHttpClientSetPerHostKeepAliveMax
-0x39700DEF _ZNK3paf7PhMicon11GetDurationEv
+0x39700DEF paf::PhMicon::GetDuration() const
 0x790C53BD _Fpcomp
 0xEB22BB86 cellRtcSetCurrentTick
 0x9D2EC4FF sys_process_spawn
-0x26E9507E _ZN3paf10MessageBox10HideDeleteEv
+0x26E9507E paf::MessageBox::HideDelete()
 0x5C8AE162 cellHttpTransactionSetUri
 0x21D67EEF cellNetCtlConnectGameInt
 0xF1A443E7 cellWebBrowserCreateRender2
-0x9FF4CD0A _ZN3paf9PhNumSpin8GetStyleEiRb
-0xB1AC1FA3 _ZNSt15basic_streambufIwSt11char_traitsIwEE6xsgetnEPwi
+0x9FF4CD0A paf::PhNumSpin::GetStyle(int, bool&)
+0xB1AC1FA3 std::basic_streambuf<wchar_t, std::char_traits<wchar_t>>::xsgetn(wchar_t*, int)
 0xAF8BB012 cellJpgDecDecodeData
-0x8F987385 _ZN7bXCeDoc10InsertNodeEP8bXCeNodeS1_S1_
+0x8F987385 bXCeDoc::InsertNode(bXCeNode*, bXCeNode*, bXCeNode*)
 0x5E91BC26 cellSysutilAvcEnumPlayers
-0xF2B9AB86 _ZNKSt7num_getIwSt19istreambuf_iteratorIwSt11char_traitsIwEEE6do_getES3_S3_RSt8ios_baseRNSt5_IosbIiE8_IostateERf
+0xF2B9AB86 std::num_get<wchar_t, std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>>::do_get(std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>, std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>, std::ios_base&, std::_Iosb<int>::_Iostate&, float&) const
 0x7DBB9A4D cellFsWidgetOpen
 0x8DCFF2CD cellFsSymbolicLink
-0x3937F2F8 _ZNKSt7num_putIcSt19ostreambuf_iteratorIcSt11char_traitsIcEEE6do_putES3_RSt8ios_basecm
+0x3937F2F8 std::num_put<char, std::ostreambuf_iterator<char, std::char_traits<char>>>::do_put(std::ostreambuf_iterator<char, std::char_traits<char>>, std::ios_base&, char, unsigned long) const
 0x260CAEDD sceNpBasicGetFriendPresenceByNpId2
-0xB4F7ED4F _ZN3paf8PhWidget8GetStyleEiiRi
+0xB4F7ED4F paf::PhWidget::GetStyle(int, int, int&)
 0x9FC527E3 SSL_get_version
 0x1D73AB8C cellSysutilAvc2LoadAsync
 0x63F63545 cellRudpInit
@@ -2541,7 +2541,7 @@
 0x887572D5 cellVideoOutGetState
 0x8B9DD4E7 dlnaPrintContinue
 0xF4BABD3F sceNpMatching2Init2
-0x2D489B47 _ZNSt15basic_streambufIcSt11char_traitsIcEE9underflowEv
+0x2D489B47 std::basic_streambuf<char, std::char_traits<char>>::underflow()
 0x8B3EBA69 cellNetCtlGetState
 0xC6B51854 sqlite3_value_double
 0x491D6BA5 cellMusicDecodeSetSelectionContext2
@@ -2550,15 +2550,15 @@
 0xAFC5D265 scePS2IconCalcSize
 0xF7E4A50A cellMediatorGetStatus
 0x6C366C43 svc1dGetVersionNumber
-0xFD61DFF5 _Z32_sce_np_sysutil_cxml_prepare_docPN16sysutil_cxmlutil11FixedMemoryERN4cxml8DocumentEPKcRNS2_7ElementES6_i
-0xB7282DC4 _Z25PSJS_ClassType_ScriptFuncv
-0x89B67B9C _ZNK3paf4View9GetStringEPKc
+0xFD61DFF5 _sce_np_sysutil_cxml_prepare_doc(sysutil_cxmlutil::FixedMemory*, cxml::Document&, char const*, cxml::Element&, char const*, int)
+0xB7282DC4 PSJS_ClassType_ScriptFunc()
+0x89B67B9C paf::View::GetString(char const*) const
 0x18EA899A cellGemGetTrackerHue
 0xC56DEFB5 cellSpursGetNumSpuThread
-0xEBE26C5E _ZNK3paf8PhCanvas9IsInheritEPKc
+0xEBE26C5E paf::PhCanvas::IsInherit(char const*) const
 0xEEAEE4EF sceSystemFileSetValueSize
 0xA80BF223 cellGameGetLocalWebContentPath
-0xEE853BAF _ZNSt13basic_filebufIwSt11char_traitsIwEE4syncEv
+0xEE853BAF std::basic_filebuf<wchar_t, std::char_traits<wchar_t>>::sync()
 0x72A577CE cellGcmGetFlipStatus
 0xD2AC48D7 iswalnum
 0x8AC6EDEE scePS2McIconSys_GetLightDir0
@@ -2567,29 +2567,29 @@
 0xDDF7E722 sceNetXmppRemoveRosterEntry
 0x9AEB5432 cellSpursBarrierGetTasksetAddress
 0xE3E4F0D6 cellGemInvalidateCalibration
-0x21659E45 _ZNKSt7num_putIcSt19ostreambuf_iteratorIcSt11char_traitsIcEEE5_FputES3_RSt8ios_basecPKcjjjj
+0x21659E45 std::num_put<char, std::ostreambuf_iterator<char, std::char_traits<char>>>::_Fput(std::ostreambuf_iterator<char, std::char_traits<char>>, std::ios_base&, char, char const*, unsigned int, unsigned int, unsigned int, unsigned int) const
 0xE40BA755 strtok
 0xF9E26B72 _Once_dtor
 0x1E479B4C cellGcmSetTransferData
 0x05BF2FBD sceNpMatching2GetWorldInfoList
-0x84E6B20D _ZN3paf6PhText13EnsureVisibleEv
+0x84E6B20D paf::PhText::EnsureVisible()
 0x6524499E _FInf
 0x85BEFFCC cellSailPlayerCloseStream
 0x9F18429D sys_prx_start_module
-0x2B50BE7D _ZNK3paf10PhItemSpin9IsInheritEPKc
+0x2B50BE7D paf::PhItemSpin::IsInherit(char const*) const
 0x0F60EB63 vfwscanf
 0x7B034C78 sys_rsxaudio_prepare_process
 0xBB42A9DD _cellGcmFunc13
 0x02FF3C1B cellSysutilUnregisterCallback
 0xC7B20E2A cellMtpSendData
 0xB4EF29D5 f_floorf
-0x10DC3F6C _ZNSbIwSt11char_traitsIwESaIwEE6appendEjw
-0xB3F05AF3 _ZNKSt7collateIcE12do_transformEPKcS2_
-0x4827E6BE _ZNKSt7num_getIcSt19istreambuf_iteratorIcSt11char_traitsIcEEE6do_getES3_S3_RSt8ios_baseRNSt5_IosbIiE8_IostateERe
+0x10DC3F6C std::basic_string<wchar_t, std::char_traits<wchar_t>, std::allocator<wchar_t>>::append(unsigned int, wchar_t)
+0xB3F05AF3 std::collate<char>::do_transform(char const*, char const*) const
+0x4827E6BE std::num_get<char, std::istreambuf_iterator<char, std::char_traits<char>>>::do_get(std::istreambuf_iterator<char, std::char_traits<char>>, std::istreambuf_iterator<char, std::char_traits<char>>, std::ios_base&, std::_Iosb<int>::_Iostate&, long double&) const
 0xFA87FA54 cellStorageDataExportDirectory
-0x5A898327 _ZNSt15basic_streambufIwSt11char_traitsIwEE7seekoffElNSt5_IosbIiE8_SeekdirENS4_9_OpenmodeE
+0x5A898327 std::basic_streambuf<wchar_t, std::char_traits<wchar_t>>::seekoff(long, std::_Iosb<int>::_Seekdir, std::_Iosb<int>::_Openmode)
 0xA445CD55 cellRemotePlayGetPeerInfo
-0x1F3A9ADA _ZNSt12strstreambuf7seekposESt4fposISt9_MbstatetENSt5_IosbIiE9_OpenmodeE
+0x1F3A9ADA std::strstreambuf::seekpos(std::fpos<std::_Mbstatet>, std::_Iosb<int>::_Openmode)
 0x9F0EFC6E exp2l
 0xCC3CCA60 cellSailAviStreamGetHeader
 0x5EEBF24E cellCameraIsStarted
@@ -2597,14 +2597,14 @@
 0x68492DE9 cellDmuxOpen
 0x5E1D9330 UHCstoUTF8s
 0x10DAE56D cellGameUpdateTerm
-0xD2F9D93D _ZNKSt7num_putIwSt19ostreambuf_iteratorIwSt11char_traitsIwEEE6do_putES3_RSt8ios_basewe
+0xD2F9D93D std::num_put<wchar_t, std::ostreambuf_iterator<wchar_t, std::char_traits<wchar_t>>>::do_put(std::ostreambuf_iterator<wchar_t, std::char_traits<wchar_t>>, std::ios_base&, wchar_t, long double) const
 0x276C72B2 sceNpSignalingSetCtxOpt
 0x3DABD5A7 EUCJPtoUTF8
 0xD6AEAC39 pafGuShadeModel
 0x4692AB35 cellAudioOutConfigure
 0x0F9667B6 cellAtracGetChannel
 0x27800C6B cellFsStRead
-0x8008F4ED _ZN19MmsDbEditableSchema6FreezeEv
+0x8008F4ED MmsDbEditableSchema::Freeze()
 0x9A58810F cellGcmSetTextureBorder
 0xA0FCDF5F pafGuGetCurrDisplayDeviceSurf
 0x3539D233 sceNpCommerce2Init
@@ -2612,7 +2612,7 @@
 0xB712D2C9 cellGcmSetDrawInlineArrayPointer
 0xA985A03B cellPesmStartMovieRec
 0xE5443BE7 cellSpursQueueAttachLv2EventQueue
-0x9111EC36 _ZNSt13messages_baseD0Ev
+0x9111EC36 std::messages_base::~messages_base()
 0x9867CDC2 svc1dDecodeSeqHeader
 0xEEB810EC FT_Outline_Transform
 0x71804D64 UCS2stoEUCCNs
@@ -2623,16 +2623,16 @@
 0xEF3EFA34 cellFsFstat
 0xFF0A2378 sceNpLookupUserProfileAsync
 0x76D867F4 svc1dGetExistenceFlag
-0x7221BAFB _Z13PSJS_ExecFuncRK11PSJSContextRK9PSJSValueRS2_iPS2_S6_
+0x7221BAFB PSJS_ExecFunc(PSJSContext const&, PSJSValue const&, PSJSValue&, int, PSJSValue*, PSJSValue*)
 0x3ACF7FF8 cellVdecGetInputStatus
-0xAF4827B4 _ZN4xMMS15GetMridFromFileEPhS0_Py
+0xAF4827B4 xMMS::GetMridFromFile(unsigned char*, unsigned char*, unsigned long long*)
 0x25B40AB4 cellGcmSortRemapEaIoAddress
 0x28B92EBF raw_spu_read_uchar
 0x0695A4B8 cellPngEncCoreExtCreate
 0x3EF17F8C __sys_look_ctype_table
 0x8EFFB7FD _cellGcmFunc2
 0x980855AC cellHttpDestroyClient
-0x4EC89BF8 _ZNSt7collateIcE7_GetcatEPPKNSt6locale5facetE
+0x4EC89BF8 std::collate<char>::_Getcat(std::locale::facet const**)
 0x45F8F3AA sceNpCustomMenuRegisterActions
 0x8E3F7EE1 cellHttpRequestSetChunkedTransferStatus
 0x2E775550 cellSpursJobQueueGetError
@@ -2643,15 +2643,15 @@
 0x2DEA3E9B cellCameraSetExtensionUnit
 0x3DA55602 fabsf
 0x52DD4E82 FT_Stream_GetOffset
-0x95748E9E _ZN3paf5Sound6Output13GetDeviceInfoEjjP26xSettingAudioOutDeviceInfo
+0x95748E9E paf::Sound::Output::GetDeviceInfo(unsigned int, unsigned int, xSettingAudioOutDeviceInfo*)
 0xFA611DF4 cellAudioOutConfigure2
 0x88419ECE smf_FOpenWithCacheSizeA
 0x62B0F803 cellMsgDialogAbort
-0xAC5563CC _ZN3paf5PhWeb4NextEv
+0xAC5563CC paf::PhWeb::Next()
 0xA5E1FA60 cellGameUpdateCheckStartWithoutDialogAsync
 0x7CDF2F53 rafLoadFromFile
 0x6C009C56 f_log10f
-0x55063D70 _ZN3paf10PhInfoList10SetItemNumEi
+0x55063D70 paf::PhInfoList::SetItemNum(int)
 0x91A99765 UHCtoUCS2
 0xD59C193C _Nan
 0xCF350A4C cellApostSrcFinalize
@@ -2659,7 +2659,7 @@
 0x17F42197 cellUsbPspcmBindAsync
 0xF2B85DFF cellCelpEncEnd
 0xD73938DF cellFsStReadFinish
-0xA3896A75 _ZNK3paf5PhWeb7HasNextEv
+0xA3896A75 paf::PhWeb::HasNext() const
 0x6F5DD7D2 cexpf
 0xD59AA307 cellSyncLFQueueGetDirection
 0x8AD55D80 cellSsAimIsDEX
@@ -2676,18 +2676,18 @@
 0xF4EF1B28 cellDtcpIpMoveOpen
 0x9A2EBFB5 smvd4FlushPicture
 0xE839380F cellMicStopEx
-0xCCF14BD5 _ZNSt7num_getIwSt19istreambuf_iteratorIwSt11char_traitsIwEEE7_GetcatEPPKNSt6locale5facetE
-0x85B3C6DA _ZNKSt8_Locinfo7_GetcvtEv
-0x4AEC14D5 _ZNSt12length_errorD1Ev
+0xCCF14BD5 std::num_get<wchar_t, std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>>::_Getcat(std::locale::facet const**)
+0x85B3C6DA std::_Locinfo::_Getcvt() const
+0x4AEC14D5 std::length_error::~length_error()
 0xC9481758 _tanf4
 0x6DFFF31D cellWebBrowserSetSystemCallbackUsrdata
 0xB30780EB cellMicGetSignalState
 0x115E2F70 spu_thread_snprintf
-0x4B5A8ABC _ZNSt13basic_filebufIwSt11char_traitsIwEE6setbufEPwi
+0x4B5A8ABC std::basic_filebuf<wchar_t, std::char_traits<wchar_t>>::setbuf(wchar_t*, int)
 0xACE0CFBA sceNpClansSearchByName
 0x7E4A4A49 cellAdecQueryAttr
 0x96B6BAA6 spu_thread_read_mem
-0x417F47AF _ZSt9use_facetISt10moneypunctIcLb0EEERKT_RKSt6locale
+0x417F47AF std::moneypunct<char, false> const& std::use_facet<std::moneypunct<char, false>>(std::locale const&)
 0xB8E8FF22 sceNpTusWaitAsync
 0x051EE3EE socketpoll
 0xF0865182 cellPrintLoadAsync2
@@ -2702,8 +2702,8 @@
 0x05C65656 sys_mempool_try_allocate_block
 0x15362BC9 spu_thread_read_long
 0x81DAF880 _LCsubcr
-0x718977C5 _ZNSt8time_getIwSt19istreambuf_iteratorIwSt11char_traitsIwEEE7_GetcatEPPKNSt6locale5facetE
-0x045E124A _ZdaPv
+0x718977C5 std::time_get<wchar_t, std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>>::_Getcat(std::locale::facet const**)
+0x045E124A operator delete[](void*)
 0x97A2F6C8 cellSpursJobHeaderSetJobbin2Param
 0xA9E81214 cellJpgEncEncodePicture
 0x4E456E81 cellUsbdFreeMemory
@@ -2724,28 +2724,28 @@
 0x8AA188E3 cellMusicGetVolume
 0xCB226149 sceNpMatchingGetRoomInfoVsh
 0x054E5064 cellCryptoPuEccEcDsaGen
-0x04EC636E _ZN3paf8PhWidget8SetStyleEii
+0x04EC636E paf::PhWidget::SetStyle(int, int)
 0x4FE14D09 cellOskDialogExtAddOptionDictionary
-0x50A5A6D3 _ZN15psjsstring_impl6DecRefEv
+0x50A5A6D3 psjsstring_impl::DecRef()
 0x3B802524 ldexpf4
 0x66B71B17 wcsspn
 0xFC48B03F cellSyncRwmInitialize
-0x724E5A8B _ZN3paf4View9PageCloseEPKc
+0x724E5A8B paf::View::PageClose(char const*)
 0xDCB6B27D sceNpMatching2RegisterRoomEventCallback
 0x95F7D9D9 cellMusicGetPlaybackStatus
-0xF87ADBD7 _ZN3paf8PhCameraC1EPNS_8PhWidgetEPNS_8PhAppearE
-0x87BBE314 _Z15pafGumTranslatePK4vec3
+0xF87ADBD7 paf::PhCamera::PhCamera(paf::PhWidget*, paf::PhAppear*)
+0x87BBE314 pafGumTranslate(vec3 const*)
 0xDC494430 cellGcmSetSecondVHandler
 0x5E7888F0 bsearch
 0xB120F6CA close
 0xC3B65D96 FT_Get_PS_Font_Private
-0xDF3A2CA7 _ZNK3paf9PhSRender8GetStyleEiR4vec4
+0xDF3A2CA7 paf::PhSRender::GetStyle(int, vec4&) const
 0x4C3F5F29 _Getgloballocale
-0x67EDDE2F _ZdlPvjRKSt9nothrow_t
+0x67EDDE2F operator delete(void*, unsigned int, std::nothrow_t const&)
 0x660D42A9 cellHttpClientSetAuthenticationCallback
 0xA713F8CF modf
 0x22AAB31D cellSpursEventFlagDetachLv2EventQueue
-0xB4352488 _ZNKSt9money_putIcSt19ostreambuf_iteratorIcSt11char_traitsIcEEE6do_putES3_bRSt8ios_basecRKSs
+0xB4352488 std::money_put<char, std::ostreambuf_iterator<char, std::char_traits<char>>>::do_put(std::ostreambuf_iterator<char, std::char_traits<char>>, bool, std::ios_base&, char, std::basic_string<char, std::char_traits<char>, std::allocator<char>> const&) const
 0x34B74160 cellGameDeleteGame
 0x1387C45C cellFontGetHorizontalLayout
 0x8BD9F160 sceNpC7yLookupCreateTransactionVsh
@@ -2781,7 +2781,7 @@
 0x66D88C8C FT_Glyph_Stroke
 0x79A6ABD0 cellKeySheapQueueDelete
 0xF007F937 smvd2FlushPicture
-0x5E1F2D37 _ZNKSt9exception8_DoraiseEv
+0x5E1F2D37 std::exception::_Doraise() const
 0xAEE8CF71 sceNpCommerceGetCategoryId
 0xB06BD868 FT_Stream_Skip
 0xD1842209 _cellAudioSetBitStreamEncoder
@@ -2789,17 +2789,17 @@
 0x7FDF4FEF cellSpursBarrierInitialize
 0x4B53C3A3 sceNpMatching2CreateJoinRoomVsh
 0x8F71C5B2 cellFsStReadWait
-0xADCC6046 _ZN3paf10PhItemSpin8GetStyleEiiR4vec4
+0xADCC6046 paf::PhItemSpin::GetStyle(int, int, vec4&)
 0x27C921B5 cellPngDecGetoFFs
-0x9D6A8167 _ZNSbIwSt11char_traitsIwESaIwEE5eraseEjj
-0x61951E4A _ZN3paf5PhWeb11SetEncodingEib
-0x7F5C551B _ZN3vsh12Infobar_OpenEN3paf12SurfaceRCPtrINS0_7SurfaceEEES3_PKwS5_i
+0x9D6A8167 std::basic_string<wchar_t, std::char_traits<wchar_t>, std::allocator<wchar_t>>::erase(unsigned int, unsigned int)
+0x61951E4A paf::PhWeb::SetEncoding(int, bool)
+0x7F5C551B vsh::Infobar_Open(paf::SurfaceRCPtr<paf::Surface>, paf::SurfaceRCPtr<paf::Surface>, wchar_t const*, wchar_t const*, int)
 0xA4F73351 FTFaceH_GetBoundingBoxMinY
 0x9338A07A cellJpgDecClose
 0x2C563C92 cellSsUmReadEprom
 0x773FF791 FT_Stroker_GetBorderCounts
-0xF7375854 _ZN10PSJSObject7SetAttrERK8psjsnameRK9PSJSValue
-0x3C186420 _ZN3paf10HeapMemoryD1Ev
+0xF7375854 PSJSObject::SetAttr(psjsname const&, PSJSValue const&)
+0x3C186420 paf::HeapMemory::~HeapMemory()
 0xB6002508 _Putstr
 0xC47C5C22 cellRescGetFlipStatus
 0x72236CBC raw_spu_write_ullong
@@ -2808,40 +2808,40 @@
 0x5468D6B0 cellSubDisplayAudioOutNonBlocking
 0x0C8F6DC5 sceNpUpdateClockInit
 0x936DF4AA sceNpCommerceGetProductId
-0x74A39B4F _ZThn8_NSt9strstreamD1Ev
+0x74A39B4F non-virtual thunk to std::strstream::~strstream()
 0x2960E309 cellHttpClientGetAutoRedirect
 0xE60EE9E5 fputws
-0xB1D696F7 _ZNKSt8numpunctIcE12do_falsenameEv
-0x577C2695 _ZNSt6_Mutex5_LockEv
-0x1B75E85F _ZN3paf7PhClock7SetTimeERKNS0_10datetime_tE
+0xB1D696F7 std::numpunct<char>::do_falsename() const
+0x577C2695 std::_Mutex::_Lock()
+0x1B75E85F paf::PhClock::SetTime(paf::PhClock::datetime_t const&)
 0x2B8A5788 sceUpdateDownloadEnd
-0x545D47A2 _ZN3paf7PhClock10WidgetTypeEv
-0x8A85D688 _ZNKSt7num_putIwSt19ostreambuf_iteratorIwSt11char_traitsIwEEE6do_putES3_RSt8ios_basewx
+0x545D47A2 paf::PhClock::WidgetType()
+0x8A85D688 std::num_put<wchar_t, std::ostreambuf_iterator<wchar_t, std::char_traits<wchar_t>>>::do_put(std::ostreambuf_iterator<wchar_t, std::char_traits<wchar_t>>, std::ios_base&, wchar_t, long long) const
 0x06A840F5 sys_dbg_set_stacksize_ppu_exception_handler
 0xED58E3EC cellSailAuReceiverFinalize
-0x643E67F4 _ZNKSt7num_getIcSt19istreambuf_iteratorIcSt11char_traitsIcEEE6do_getES3_S3_RSt8ios_baseRNSt5_IosbIiE8_IostateERPv
-0xF5BEB953 _ZNK3paf4View8ArgumentcvSsEv
-0x0339259C _ZNKSt7num_putIcSt19ostreambuf_iteratorIcSt11char_traitsIcEEE6do_putES3_RSt8ios_basecPKv
+0x643E67F4 std::num_get<char, std::istreambuf_iterator<char, std::char_traits<char>>>::do_get(std::istreambuf_iterator<char, std::char_traits<char>>, std::istreambuf_iterator<char, std::char_traits<char>>, std::ios_base&, std::_Iosb<int>::_Iostate&, void*&) const
+0xF5BEB953 paf::View::Argument::operator std::basic_string<char, std::char_traits<char>, std::allocator<char>>() const
+0x0339259C std::num_put<char, std::ostreambuf_iterator<char, std::char_traits<char>>>::do_put(std::ostreambuf_iterator<char, std::char_traits<char>>, std::ios_base&, char, void const*) const
 0x642F7D6B f_copysignf
 0xC15BE817 cellVideoExportFinalize
 0xA11552F6 cellSysutilGetBgmPlaybackStatus
-0x82218722 _ZN3paf10PhSaveData15SetRotationRateEf
+0x82218722 paf::PhSaveData::SetRotationRate(float)
 0x38B28212 _cellAudioPathThroughSpdifSetEventCallback
-0x7CDBDA48 _ZNSt7collateIcED0Ev
+0x7CDBDA48 std::collate<char>::~collate()
 0x938BFCF7 spu_thread_write_char
 0xE4944A1C cellSpursCreateTask2WithBinInfo
 0x8DE11580 sceNpMatching2SendLobbyInvitationVsh
-0xBD091E26 _ZN4cell5Daisy4Lock15completeConsumeEj
-0x1FBFAA13 _ZN3paf5Image12ToCLUTBufferEb
+0xBD091E26 cell::Daisy::Lock::completeConsume(unsigned int)
+0x1FBFAA13 paf::Image::ToCLUTBuffer(bool)
 0x56779FBD sceNpC7yScoreInitVsh
 0x3A33C1FD _cellGcmFunc15
 0xC5447A90 cellOskDialogExtSetPointerEnable
-0x336E904E _ZNSdD0Ev
+0x336E904E std::basic_iostream<char, std::char_traits<char>>::~basic_iostream()
 0xF12EECC8 cellFsRename
-0xF4E3246A _ZN3vsh22ScreenSaver_CheckTimerEv
+0xF4E3246A vsh::ScreenSaver_CheckTimer()
 0x41AE9C31 cellGemUpdateFinish
-0xBB12535D _ZN3paf8PhXmList9SelectOutEf
-0x0BA57D3D _ZN3paf10PhSPrimDivD1Ev
+0xBB12535D paf::PhXmList::SelectOut(float)
+0x0BA57D3D paf::PhSPrimDiv::~PhSPrimDiv()
 0xB12F5364 gnpc_resp_get_bytes
 0x7F0A3EAF cellUsbPspcmPollSendAsync
 0x2357BA9E sceNpTusGetMultiSlotVariableVUser
@@ -2851,7 +2851,7 @@
 0x53F2DED8 mvcDecReset
 0x1702D114 cellMarlinDLInit
 0xDCE51399 cellWebComponentDestroy
-0x82567DC3 _ZN3paf10PhSaveData16SetRotationSpeedEf
+0x82567DC3 paf::PhSaveData::SetRotationSpeed(float)
 0x81B22CA8 cellAtracMultiSetDataAndGetMemSize
 0xC851A4C0 cellSysutilAvcExtStartVoiceDetection
 0x3F680668 sceNpC7yLookupUserProfileRequestVsh
@@ -2873,43 +2873,43 @@
 0x74902D4B expf4fast
 0xE44F29F4 cellFsUtilityMount
 0xB874CADD smf_ApPs_GetAVCSeqParamSetExt
-0x9576C835 _ZN3paf5Image6ResizeERKNS_11ImageExtentENS_12OpResizeTypeE
+0x9576C835 paf::Image::Resize(paf::ImageExtent const&, paf::OpResizeType)
 0xCD33F3E2 cellVpostOpen
 0x2C0F3548 sceNpSnsFbInit
-0x05EC37C8 _ZSt10_MaklocstrIwEPT_PKcS1_RKSt7_Cvtvec
+0x05EC37C8 wchar_t* std::_Maklocstr<wchar_t>(char const*, wchar_t*, std::_Cvtvec const&)
 0x2BF4DDD2 cellVdecDecodeAu
 0xFA45245D cellAvsetSetRouteAndColor
 0xE9B560A5 sscanf
 0x74C37666 _cellSyncLFQueueGetPopPointer
 0x5B1E4D7A cellSync2CondEstimateBufferSize
-0xEA225A69 _ZN3paf13PhApplication15CalcLayoutValueEiiiRK4vec4
+0xEA225A69 paf::PhApplication::CalcLayoutValue(int, int, int, vec4 const&)
 0x8BB608E4 cellHttpUtilParseUriPath
 0x748029A2 sceNpMatching2RegisterContextCallback
-0x84529ACC _ZN3paf5Image9SetExtentERKNS_11ImageExtentENS_12OpResizeTypeE
+0x84529ACC paf::Image::SetExtent(paf::ImageExtent const&, paf::OpResizeType)
 0x8DFABC0A FTCacheStream_CacheInit
-0xDB9195CE _ZN3paf8PhXmItem12AnimIconMoveERK4vec4ffiii
+0xDB9195CE paf::PhXmItem::AnimIconMove(vec4 const&, float, float, int, int, int)
 0x0F0A07EA InputDevice_SetKeyAssign
 0x8CBDCBAC cellVideoPlayerSetDownloadPosition
 0xD477852D logf
 0xDC151707 _f_log2f
-0x6B493669 _ZSt7setbasei
+0x6B493669 std::setbase(int)
 0x9DC04436 cellGcmBindZcull
-0xDA1A7C4C _ZN3paf8PhCanvas8FinalizeEi
+0xDA1A7C4C paf::PhCanvas::Finalize(int)
 0xE74FAB55 cellFt2dBitBltImm
-0x7B5FCE95 _ZNSt15basic_streambufIwSt11char_traitsIwEE6setbufEPwi
+0x7B5FCE95 std::basic_streambuf<wchar_t, std::char_traits<wchar_t>>::setbuf(wchar_t*, int)
 0x2D6B25EA pafGuTexScale
 0xCB905530 sceLoginServiceInit
 0xAEC7C970 lseek
 0xA839A4D9 cellSpursAttributeSetSpuThreadGroupType
-0xD4838FBD _ZNKSt7num_putIwSt19ostreambuf_iteratorIwSt11char_traitsIwEEE6do_putES3_RSt8ios_basewm
+0xD4838FBD std::num_put<wchar_t, std::ostreambuf_iterator<wchar_t, std::char_traits<wchar_t>>>::do_put(std::ostreambuf_iterator<wchar_t, std::char_traits<wchar_t>>, std::ios_base&, wchar_t, unsigned long) const
 0x951D8EA1 smf_FInit
-0x91CD1263 _ZN3paf6PhText15SetColumnOffsetEf
-0x7EE103EF _ZN3paf4View12PageActivateEPKc
+0x91CD1263 paf::PhText::SetColumnOffset(float)
+0x7EE103EF paf::View::PageActivate(char const*)
 0x10B81ED6 sys_net_set_udpp2p_test_param
-0x77C1D3A9 _ZNKSt13runtime_error8_DoraiseEv
+0x77C1D3A9 std::runtime_error::_Doraise() const
 0x4B478CDD FTFaceH_GetAscender
-0xA166B23E _ZN3paf8PhXmList10SetItemNumEi
-0xBC2C23A8 _ZN3paf8PhScrollC1EPNS_8PhWidgetEPNS_8PhAppearE
+0xA166B23E paf::PhXmList::SetItemNum(int)
+0xBC2C23A8 paf::PhScroll::PhScroll(paf::PhWidget*, paf::PhAppear*)
 0x5B6ADA55 cellImeJpEnterCharExt
 0x081C98BE cellFiberPpuContextRunScheduler
 0xC1566DAE cellM4hdEncGetStream2
@@ -2918,21 +2918,21 @@
 0xBEB72963 cellAsfSeekTime
 0x3902363A malloc_footprint
 0x71F86685 FTFaceH_GetBoundingBoxMinX
-0xEBDBCA6D _ZN4xMMS30DestroyGenerateMetadataContextEP19xMMSGenerateContext
+0xEBDBCA6D xMMS::DestroyGenerateMetadataContext(xMMSGenerateContext*)
 0x8AB0ABC6 strncpy
 0x2AB0D183 cellBGDLGetInfo2
 0x9153BDF4 sceNpBasicGetMessageAttachmentEntryCount
 0x66130F5D cellDecPsnvideoOpenTrack
 0x73A2C895 _SceAdecCorrectPtsValue_Mp3s
-0xAA520D9F _ZNSt6locale7_Locimp7_AddfacEPNS_5facetEj
+0xAA520D9F std::locale::_Locimp::_Addfac(std::locale::facet*, unsigned int)
 0x461534B4 cellPamfReaderSetStreamWithIndex
-0x2ADCCB1A _ZNKSt7_MpunctIcE14do_frac_digitsEv
+0x2ADCCB1A std::_Mpunct<char>::do_frac_digits() const
 0xC291E698 exit
-0xE22D7B0C _ZN3paf9PhSRender8SetStyleEii
+0xE22D7B0C paf::PhSRender::SetStyle(int, int)
 0x69726AA2 cellSpursAddWorkload
 0x6E952645 cellPrintGetPrintableArea
 0x749440F9 lgammal
-0x7BF509AF _ZN11PSJSContext17RegistMethodToObjER9PSJSValuePK12PSJSAPIEntry
+0x7BF509AF PSJSContext::RegistMethodToObj(PSJSValue&, PSJSAPIEntry const*)
 0x25DA8FBB iscntrl
 0xD9C63AFB cellVideoPlayerGetOutputStereoPicture
 0x3EC99A66 _Getptimes
@@ -2946,23 +2946,23 @@
 0x487DE998 sceNpClansGetClanInfo
 0x698897F8 cellFontGetVerticalLayout
 0xD7138829 PhiSetLayoutTable
-0xE7D8449E _ZdlPvjS_
+0xE7D8449E operator delete(void*, unsigned int, void*)
 0xAB6B6DBF cellAtracGetLoopInfo
 0x4A6465E3 cellSpursCreateTaskset2
 0x661FE266 _cellGcmFunc12
 0xA9A439E0 cellWebBrowserConfigSetUnknownMIMETypeHook2
 0x63441CB4 cellGcmMapEaIoAddress
-0x6BDB86A9 _ZN3paf8PhWidget16SetMetaAlphaModeEi
-0x695E35BE _ZN3paf8PhWidget14GetLayoutStyleEiRiRf
+0x6BDB86A9 paf::PhWidget::SetMetaAlphaMode(int)
+0x695E35BE paf::PhWidget::GetLayoutStyle(int, int&, float&)
 0x57E01799 cellGcmSetDepthFunc
 0xBEB9EE7A cellJpgEncCoreOpen
 0x2E267B28 FTFaceH_FontFamilyName
 0xE3D28395 cellFsSetAttribute
-0xCC9C89FB _ZN3paf8SyncCallD1Ev
+0xCC9C89FB paf::SyncCall::~SyncCall()
 0xF80196C1 cellGcmGetLabelAddress
 0x1BE16005 EVP_PKEY_free
 0xB0FA1592 clog10l
-0xC763FEB7 _ZN3paf5PhWeb4PrevEv
+0xC763FEB7 paf::PhWeb::Prev()
 0x5161DDBD cellPadConfigInit
 0x12DF5AF5 _cellAudioPathThroughLRCK_getIndexAddr
 0x5C36E44F FT_Render_Glyph
@@ -2970,7 +2970,7 @@
 0xE0CEF79E cellRescCreateInterlaceTable
 0x7B4DEEAD cellAvsetSetRSXAudioMute
 0x215B0D75 sceNpMatching2SetRoomDataExternal
-0x07A3BD16 _ZNSt6locale7_LocimpD1Ev
+0x07A3BD16 std::locale::_Locimp::~_Locimp()
 0x2B45CB34 wcsrtombs
 0xE4969D9D FT_Vector_Unit
 0x415ED9DC cellSubDisplayGetTouchInfo
@@ -2982,7 +2982,7 @@
 0xA86B28E3 cellRudpGetSizeWritable
 0x4B33942A cellHttpClientAddHeader
 0xA65A3868 pafGuCgCreateShader
-0x94C49383 _ZdlPvS_
+0x94C49383 operator delete(void*, void*)
 0x30FB2899 _Getmem
 0x434881A0 cacosf
 0x9413678F cellDtcpIpCheckActivation
@@ -2990,11 +2990,11 @@
 0xCFEE82D8 _remainderf4
 0x01CEA187 cellGcmCgGetAttribOutputMask
 0x42A2E133 cellGameCreateGameData
-0xEB637C94 _ZN7bXCeDoc20GetElementsByTagNameEP8bXCeNodePc
+0xEB637C94 bXCeDoc::GetElementsByTagName(bXCeNode*, char*)
 0x4AB0B9B9 sys_net_set_test_param
-0x45010630 _ZNSt10moneypunctIcLb1EED0Ev
+0x45010630 std::moneypunct<char, true>::~moneypunct()
 0x0109F3D3 cellFontGetRenderEffectWeight
-0xAFB4ECB9 _ZN3paf8PhWidget12SetLayoutPosEiii4vec4
+0xAFB4ECB9 paf::PhWidget::SetLayoutPos(int, int, int, vec4)
 0x23DC28E8 cellSysutilEventPortSend
 0xACFE51D8 FT_GlyphLoader_Done
 0x0AF1F161 xSettingSystemInfoGetInterface
@@ -3006,68 +3006,68 @@
 0x833E6B0E cimag
 0x246EA8D0 f_sqrtf
 0x9D74740F FT_Get_Sfnt_Name
-0x460E5CB7 _ZNSt13basic_filebufIcSt11char_traitsIcEE7seekposESt4fposISt9_MbstatetENSt5_IosbIiE9_OpenmodeE
+0x460E5CB7 std::basic_filebuf<char, std::char_traits<char>>::seekpos(std::fpos<std::_Mbstatet>, std::_Iosb<int>::_Openmode)
 0x70258515 sys_mmapper_allocate_memory_from_container
 0x728149E5 f_ldexpf
 0x4EDCDBF7 cellGcmSetBlendEnable
-0xBF4B155C _ZN3paf8PhWidget15UpdateLayoutPosEv
+0xBF4B155C paf::PhWidget::UpdateLayoutPos()
 0xB57BDF7B iswxdigit
 0x483CBA61 sceWaveAudioSetVolumeEx
 0xD9AB9AE4 ft_validator_init
 0xEB4716D4 cellAvsetSetVideoMute
 0xD8F88E1A _cellGcmSetFlipCommandWithWaitLabel
 0xEE530059 sceNpCommerceGetSkuName
-0x4E6D10A5 _ZNK3paf10PhSaveData12GetFrameLoopERfS1_
+0x4E6D10A5 paf::PhSaveData::GetFrameLoop(float&, float&) const
 0xDE7833F2 _log2f4fast
 0x57854875 sceNpCommerceDoCheckoutStartVsh
-0x7177FF24 _ZN3paf5PhWeb22SetChangeTitleCallbackEPFvPS0_PKwE
-0x11E195B3 _ZNK3paf4View8PageRootEPKc
+0x7177FF24 paf::PhWeb::SetChangeTitleCallback(void (*)(paf::PhWeb*, wchar_t const*))
+0x11E195B3 paf::View::PageRoot(char const*) const
 0xEB27885B cellAuthDialogAbort
-0x34234BF0 _ZN4cell5Daisy22ScatterGatherInterlockC2EPVNS0_16_AtomicInterlockEjPjjh
+0x34234BF0 cell::Daisy::ScatterGatherInterlock::ScatterGatherInterlock(cell::Daisy::_AtomicInterlock volatile*, unsigned int, unsigned int*, unsigned int, unsigned char)
 0x6CC7AE00 cellMicSetNotifyEventQueue2
 0x3F9A35FD FTFaceH_GetCompositeCodes
-0xC41D676D _ZNSt9time_baseD2Ev
+0xC41D676D std::time_base::~time_base()
 0x5267CB35 sys_spinlock_unlock
-0xDA5469B3 _ZNSt9time_baseD0Ev
+0xDA5469B3 std::time_base::~time_base()
 0xD0230671 cellPamfReaderGetNumberOfSpecificStreams
 0xFB0F0018 _Makewct
 0xE9BF2110 _cellSyncLFQueueGetPushPointer
-0xCB864F5D _ZN3paf11PhLabelText21SetPrivateSurfacePoolEPNS_11SurfacePoolE
+0xCB864F5D paf::PhLabelText::SetPrivateSurfacePool(paf::SurfacePool*)
 0xA975EBB4 sceNpCommerce2GetProductInfoCreateReq
 0xC4796A45 cellImeJpGetCandidateListSize
 0x5B474C22 casinhl
 0x9AB20793 cellPamfReaderGetStreamTypeAndChannel
-0x928FBE36 _ZTv0_n12_NSdD1Ev
-0x7C7F21E0 _ZN3vsh22ScreenSaver_ResetTimerEv
-0xC2F5EAF9 _ZN3paf7PhEventC1EjPNS_8PhWidgetEjiiii
+0x928FBE36 virtual thunk to std::basic_iostream<char, std::char_traits<char>>::~basic_iostream()
+0x7C7F21E0 vsh::ScreenSaver_ResetTimer()
+0xC2F5EAF9 paf::PhEvent::PhEvent(unsigned int, paf::PhWidget*, unsigned int, int, int, int, int)
 0x0266A34C SSL_set_connect_state
 0x2B68C241 cellMarlinDRMActionDescribe
 0x16AA3407 cellAvsetSetVideoPitch
 0x77E241BC _Skip
-0x4E348797 _ZN3paf10PhItemSpin8SetStyleEiii
+0x4E348797 paf::PhItemSpin::SetStyle(int, int, int)
 0xCF01D5D4 cellAtracGetSoundInfo
 0xE36F2A6C smvd2GetSideInfoSeq
 0x3C863B04 FT_Outline_Copy
-0xFE119299 _ZN3paf6PhText10SetVScrollEPNS_8PhScrollE
+0xFE119299 paf::PhText::SetVScroll(paf::PhScroll*)
 0x104551A6 sceNpCommerce2DoCheckoutStartAsync
 0xFCE9E764 cellGcmInitSystemMode
 0xA2D6CBD2 sys_dbg_get_semaphore_information
 0x602E2052 cellCameraGetDeviceGUID
 0xE15679FE cellSailVideoConverterGetResult
-0xF2034429 _ZN4cell5Daisy16LFQueue2PushOpenEPNS0_8LFQueue2E
+0xF2034429 cell::Daisy::LFQueue2PushOpen(cell::Daisy::LFQueue2*)
 0x90C2BB19 cellSysutilApOff
 0xD0EA47A7 sys_prx_unregister_library
 0x75744E2A cellRtcTickAddDays
 0xC4F573B8 cellVoiceWriteToIPortEx2
 0xE2C5274A _WStoflt
-0xA97D0803 _ZN3paf8PhWidget8SetStyleEif
+0xA97D0803 paf::PhWidget::SetStyle(int, float)
 0x893305FA sys_raw_spu_load
 0x85CD04CD _cellSpursJobQueuePortPushJobBody
 0xCBC06973 cellPesmFinalize2
 0xADA45B84 sceNpClansPostAnnouncement
 0x77D8037F cellCameraStartAsync
 0xAC58AD2B cellSysutilEnableBgmPlaybackEx
-0x0CC51D56 _ZN3paf7Surface4CopyEiPKv10ImageOrderii
+0x0CC51D56 paf::Surface::Copy(int, void const*, ImageOrder, int, int)
 0x4C9F0992 sceNpGetPsHandle
 0x34A93B01 msmw_Init
 0x2347890D canonPrintEndPage
@@ -3083,17 +3083,17 @@
 0xBA50640E sqlite3_bind_double
 0x33CF63E8 sjvtdSetDecodeMode
 0xCB24A2FB cellMcadptInit
-0xF53021E0 _ZNSt8bad_castC1Ev
+0xF53021E0 std::bad_cast::bad_cast()
 0x245FF230 cellSysutilAvcExtSetWindowPosition
 0x8A86B77C cellSsUmAllocateBuffer
 0x889D5804 _Dunscale
-0xAD6D839F _ZNSt12codecvt_baseD0Ev
+0xAD6D839F std::codecvt_base::~codecvt_base()
 0xAC77BA69 cellFt2dScaling
 0x3ACE58F3 cellMicSysShareClose
-0xE801C345 _ZN3paf10PhProgress10WidgetTypeEv
+0xE801C345 paf::PhProgress::WidgetType()
 0x98B9408D sjvtdGetAuxData
 0x29DA1EA6 cellCelp8EncWaitForOutput
-0x2C6CE396 _ZNKSt7num_getIcSt19istreambuf_iteratorIcSt11char_traitsIcEEE6do_getES3_S3_RSt8ios_baseRNSt5_IosbIiE8_IostateERd
+0x2C6CE396 std::num_get<char, std::istreambuf_iterator<char, std::char_traits<char>>>::do_get(std::istreambuf_iterator<char, std::char_traits<char>>, std::istreambuf_iterator<char, std::char_traits<char>>, std::ios_base&, std::_Iosb<int>::_Iostate&, double&) const
 0xE1E3DF5F cellMgVideoConnect
 0x75211196 cellSpursReadyCountAdd
 0x6621A82C sjis2kuten
@@ -3104,8 +3104,8 @@
 0x216984ED spu_thread_write_long
 0x9E445E9F cellAvsetEnd
 0xD37FB694 cellSailRecorderCancel
-0xD356AEFD _ZNSt6_Mutex7_UnlockEv
-0x68904EC2 _ZN3paf7PhMicon12SetMovieTypeEi
+0xD356AEFD std::_Mutex::_Unlock()
+0x68904EC2 paf::PhMicon::SetMovieType(int)
 0x59859D36 cellMp3EncOpen
 0x011EE38B _cellSpursLFQueueInitialize
 0x8BEFAC67 cellGemGetCameraState
@@ -3116,24 +3116,24 @@
 0x898C77BF cellUserTraceTerminate
 0xB15E9321 sys_netset_get_key_value
 0xCF03F47A cellPadConfigAssignPortID
-0x7EE0068F _ZN3vsh22SetDateTimeDisplayTypeEii
+0x7EE0068F vsh::SetDateTimeDisplayType(int, int)
 0x11BECCE5 CEUQueue_create
 0x1057762D scePS2McIconSys_GetDeleteIconFileName
 0x8AFB8356 cellFiberPpuSendSignal
-0x90F4F801 _ZN3paf14PhCheckBoxList10WidgetTypeEv
-0x2883F1FC _ZN3paf10PhProgress18RequestChangeValueEffi
-0x134034CE _ZN8cxmlutil6GetIntERKN4cxml7ElementEPKcPi
+0x90F4F801 paf::PhCheckBoxList::WidgetType()
+0x2883F1FC paf::PhProgress::RequestChangeValue(float, float, int)
+0x134034CE cxmlutil::GetInt(cxml::Element const&, char const*, int*)
 0xE8A67160 sceNpScoreGetClansMembersRankingByNpIdAsync
-0xF83E8D95 _ZNKSt5ctypeIcE10do_tolowerEc
-0x541F8EBB _ZN3paf9Framework9InitParamC1Ev
+0xF83E8D95 std::ctype<char>::do_tolower(char) const
+0x541F8EBB paf::Framework::InitParam::InitParam()
 0x3AD203FA lrint
 0x23F0FD4E _cellSslIsInitd
 0x03593D2C _f_expf
-0x816D1A8F _ZN3paf10PhInfoListC1EPNS_8PhWidgetEPNS_8PhAppearE
+0x816D1A8F paf::PhInfoList::PhInfoList(paf::PhWidget*, paf::PhAppear*)
 0xFDC00061 cellGcmSetWriteBackEndLabel
 0x73096858 wctob
 0xA20827A8 ctanl
-0xF5825C7D _ZNSt7collateIwED1Ev
+0xF5825C7D std::collate<wchar_t>::~collate()
 0xE51A4944 sceNpCommerce2GetGameProductInfoFromContentInfo
 0x31D9BA8D cellSslCertGetNotBefore
 0x38579EC9 cellGameSetExitParam
@@ -3157,9 +3157,9 @@
 0x3F76E3CD cellDmuxQueryAttr2
 0xFA07D320 cellUsbPspcmClose
 0x55944323 InputDevice_IsOwner
-0x03CCA12F _ZNSt6localeC1ERKS_PKci
-0x818162F2 _ZN3paf9PhHandler11SetDeleteCBEPFvPNS_8PhWidgetEPNS_7PhEventEPvES5_
-0x3E18602A _ZNKSt12codecvt_base13do_max_lengthEv
+0x03CCA12F std::locale::locale(std::locale const&, char const*, int)
+0x818162F2 paf::PhHandler::SetDeleteCB(void (*)(paf::PhWidget*, paf::PhEvent*, void*), void*)
+0x3E18602A std::codecvt_base::do_max_length() const
 0xC155A73F _WStoull
 0x8B5C1AE5 sceNpMatchingReleaseCtx
 0x0553AE54 FT_Stream_ReadOffset
@@ -3170,11 +3170,11 @@
 0xBA78E51F cellHttpClientGetRecvTimeout
 0x832DF17E cellAudioAdd6chData
 0x77C3067F Zi8SetPDremoveOpt
-0x86E89034 _ZNK3paf7PhSPrim8GetStyleEiRi
-0x84FC5B16 _ZN3paf10MessageBox30SetQueryProgressBarInfoHandlerEPFvPNS0_15ProgressBarInfoEE
+0x86E89034 paf::PhSPrim::GetStyle(int, int&) const
+0x84FC5B16 paf::MessageBox::SetQueryProgressBarInfoHandler(void (*)(paf::MessageBox::ProgressBarInfo*))
 0x2033B878 cellHttpClientCloseAllConnections
 0xB287748C cellRtcAlarmStopRunning
-0xB6C9D197 _ZN3vsh10ScrollText16SetStatusHandlerEPFviPvES1_
+0xB6C9D197 vsh::ScrollText::SetStatusHandler(void (*)(int, void*), void*)
 0xA52D2AE4 cellMicGetType
 0x3F72C56E cellKbSetLEDStatus
 0x35F22AC3 cellUsbdEnd
@@ -3188,26 +3188,26 @@
 0xBE07C708 sceNpManagerGetOnlineId
 0x85FB7363 cellHttpClientSetConnectionStateCallback
 0x8FE376A6 cellSearchCancel
-0xE31907BE _ZN3paf7PhSPrim6RenderEPKNS_8PhWidgetERK4vec4b
+0xE31907BE paf::PhSPrim::Render(paf::PhWidget const*, vec4 const&, bool)
 0x97FF2AF1 cellAdecGetPcm
 0x88E009F5 vwprintf
 0x34CC0CA4 sceNpMatchingKickRoomMember
 0xCA8181C1 cellPamfGetHeaderSize
 0x941F9C4E cellPesmUnloadAsync
 0x919FF7E5 _cellGcmInitInternal
-0x61295FFE _ZN7bXCeDoc10ImportNodeEP8bXCeNodeS1_PS_S1_
+0x61295FFE bXCeDoc::ImportNode(bXCeNode*, bXCeNode*, bXCeDoc*, bXCeNode*)
 0x82AAB310 naacEncQueryMemorySize
 0xE5F09C80 llabs
-0x9437A62E _ZN3paf5Sound6Output17ConfigureAudioOutEj32xSettingDisplayAudioOutConfigure
+0x9437A62E paf::Sound::Output::ConfigureAudioOut(unsigned int, xSettingDisplayAudioOutConfigure)
 0xF42C0DF8 sceNpManagerGetOnlineName
 0xEB6FCFF1 cellAudioInRegisterDevice
 0x18B26998 remainderl
 0x80A29E27 cellSpursSetPriorities
 0x61C90691 cellHttpRecvResponse
 0x33F54920 FT_QAlloc
-0xD5244A29 _ZNSt10moneypunctIwLb1EE7_GetcatEPPKNSt6locale5facetE
+0xD5244A29 std::moneypunct<wchar_t, true>::_Getcat(std::locale::facet const**)
 0x01711E81 sceNpTusDeleteMultiSlotDataVUser
-0x2BE4DDE1 _ZN4cell5Daisy29LFQueue2HasUnfinishedConsumerEPNS0_8LFQueue2Ej
+0x2BE4DDE1 cell::Daisy::LFQueue2HasUnfinishedConsumer(cell::Daisy::LFQueue2*, unsigned int)
 0x9E8130B6 ccos
 0xED20E079 cellSearchGetMusicSelectionContextOfSingleTrack
 0x750813C6 cellMp3EncWaitForOutput
@@ -3215,26 +3215,26 @@
 0x708A9A5D cellGcmSetTransferImage
 0x012AC753 cellAvcEncSmallGetAuInfo
 0xEADCB5CA sceNpMatchingCreateRoomWithoutGUI
-0x64115670 _ZN3paf11SurfacePool4FreeEPv
+0x64115670 paf::SurfacePool::Free(void*)
 0x33D6AE54 ferror
 0xF5376485 FTFaceH_GetBoundingBoxWidth
-0x778F2E4D _ZNK3paf8PhCanvas9GetStatusEv
-0x9BDBC48F _ZNK3paf7PhModel16GetCurrentMotionEv
+0x778F2E4D paf::PhCanvas::GetStatus() const
+0x9BDBC48F paf::PhModel::GetCurrentMotion() const
 0xB5542E5A cellVideoPlayerOpen
 0x112EA8EA strspn
 0x080A92FA atx_encode
-0x01D9B3F5 _ZNSt6localeC1EPKci
+0x01D9B3F5 std::locale::locale(char const*, int)
 0xA7A090E5 sceNpScorePollAsync
 0xE4140D31 bXCeMemFree
 0x44CF744B tanhl
 0x7A69ECC1 cellSysutilAvc2SetWindowAttribute
 0x21AA3045 UTF32stoUTF8s
-0x26ED24A6 _ZN3paf8PhWidget18HandleFocusInEventEPNS_7PhEventE
-0x837CAE6A _Z30PSJS_BuildValueImpl_NativeFuncRK11PSJSContextPFbS1_R9PSJSValue12PSJSCallTypeiPS2_S5_Eh
-0x2CF8EA50 _ZNKSt7codecvtIwcSt9_MbstatetE16do_always_noconvEv
-0x022FDDB8 _ZN3paf6PhText7SetSizeEfff
-0xB7377945 _ZN3paf10PhCheckBox6CreateEv
-0xDE9C6F25 _ZN3paf15CriticalSectionD1Ev
+0x26ED24A6 paf::PhWidget::HandleFocusInEvent(paf::PhEvent*)
+0x837CAE6A PSJS_BuildValueImpl_NativeFunc(PSJSContext const&, bool (*)(PSJSContext const&, PSJSValue&, PSJSCallType, int, PSJSValue*, PSJSValue*), unsigned char)
+0x2CF8EA50 std::codecvt<wchar_t, char, std::_Mbstatet>::do_always_noconv() const
+0x022FDDB8 paf::PhText::SetSize(float, float, float)
+0xB7377945 paf::PhCheckBox::Create()
+0xDE9C6F25 paf::CriticalSection::~CriticalSection()
 0x75E3E2E9 nearbyintl
 0xE4B07F1E scePS2McIconSys_DeleteIconFileName
 0x11BC3A6C cellDmuxOpen2
@@ -3242,17 +3242,17 @@
 0x09565B21 cellOskDialogExtInputDeviceUnlock
 0x0A3EA2A9 cellSailRecorderSetParameter
 0xD1D69CB8 _Stod
-0xB87C4B43 _ZNSt12strstreambuf6freezeEb
+0xB87C4B43 std::strstreambuf::freeze(bool)
 0xE08F3910 cellJpgDecSetParameter
 0xFBC82301 sceNpScoreGetRankingByRange
 0x96EA4DE6 wctomb
-0xCD707F5B _ZN3paf5PhWeb14getWindowWidthEv
+0xCD707F5B paf::PhWeb::getWindowWidth()
 0x931FF25A L10nConvertStr
-0xD6135FC4 _ZN3paf8PhWidget14SetLayoutStyleEiiiii4vec4
+0xD6135FC4 paf::PhWidget::SetLayoutStyle(int, int, int, int, int, vec4)
 0x1A3FCB69 sceNpCommerceGetSkuUserData
 0x74D22119 cellSysutilAvc2StartStreaming
 0x7CC3DFE7 SSL_free
-0xF5C605E3 _Z35xcbGetDestinationStorageMediaRecordPvPS_
+0xF5C605E3 xcbGetDestinationStorageMediaRecord(void*, void**)
 0x6C1FFE4E cellHttpCookieImport
 0x08598228 PAF_Resource_DOMGetNodeFirstChild
 0xE956BF64 FT_Done_FreeType
@@ -3263,15 +3263,15 @@
 0xA0160C30 _copysignf4
 0x303D9027 sceNpC7yTusAbortVsh
 0xD990858B BIG5stoUTF8s
-0x1DCA42A6 _ZN3paf6PhSpin8SetStyleEii
+0x1DCA42A6 paf::PhSpin::SetStyle(int, int)
 0xF70F8A7F FT_Stream_ReadFields
 0x74BFAD12 cellRudpGetContextStatus
 0x8155D5A6 sceNpMatchingSetRoomSearchFlagVsh
 0x141F0CC1 cellMgVideoSetThreadPriority
 0xA0D9223C cellHttpTransactionCloseConnection
 0x98DC7D0D sceNpMatchingKickRoomMemberVsh
-0x3242B3F4 _ZNK3paf8PhWidget13GetLayoutSizeERiS1_S1_R4vec4
-0xEC289A5A _ZN7bXUtils10InitializeEv
+0x3242B3F4 paf::PhWidget::GetLayoutSize(int&, int&, int&, vec4&) const
+0xEC289A5A bXUtils::Initialize()
 0x726DFFD5 sceNpClansCancelInvitation
 0x417851CE feholdexcept
 0x1479961A cellGcmTransferDataFormat
@@ -3286,7 +3286,7 @@
 0x7C4BA244 cellVideoPlayerSetStopPosition
 0x1C9A942C sys_lwcond_destroy
 0x9F03DD3E lgammaf
-0x106D7436 _ZNK7bXCeDoc10GetSiblingEP8bXCeNode
+0x106D7436 bXCeDoc::GetSibling(bXCeNode*) const
 0x63387071 cellGcmGetLastFlipTime
 0xA9F945B3 sceNpCommerce2DoProductCodeFinishAsync
 0x35CDA406 cellSearchGetContentInfoDeveloperData
@@ -3297,15 +3297,15 @@
 0x0561448B sceNpCommerceGetDataFlagAbort
 0x5B1E2C73 cellAudioPortStop
 0x60440C73 sceNpManagerSubSigninAbortGui
-0x1A7F963C _ZNKSt8numpunctIcE11do_truenameEv
+0x1A7F963C std::numpunct<char>::do_truename() const
 0xA447A781 cellAvcEncSmallQueryPresetParameter
 0x0AE275A4 _Stolx
-0x5D836E75 _ZN3paf10Job_CancelEPNS_9Job_QueueEPNS_10Job_ThreadEi
-0x7001CAC7 _ZN3paf10MessageBox12GetSpaceInfoEPNS0_9SpaceInfoE
+0x5D836E75 paf::Job_Cancel(paf::Job_Queue*, paf::Job_Thread*, int)
+0x7001CAC7 paf::MessageBox::GetSpaceInfo(paf::MessageBox::SpaceInfo*)
 0xFAEC8C60 fprintf
 0xC11F8056 _cellFiberPpuAttributeInitialize
 0x842CB14D _log1pf4
-0xE011E7D0 _ZN3vsh27ShowButtonNavigation_OptionEb
+0xE011E7D0 vsh::ShowButtonNavigation_Option(bool)
 0x3D1460E9 _Strerror
 0xFA8D5F95 cellFiberPpuExit
 0x4D7CE993 cellGcmSetSecondVFrequency
@@ -3322,10 +3322,10 @@
 0x44951709 FT_Glyph_Get_CBox
 0x915D28A3 cellAvsetSetCGMSWSSData
 0xA0DDBA8E _Stoulx
-0xB172E9CB _ZN4cxml8Document13WriteToBufferEPvj
+0xB172E9CB cxml::Document::WriteToBuffer(void*, unsigned int)
 0xD69C513D _Wcscollx
 0x26FA81B4 cellSpursJobQueuePortFinalize
-0x933B103D _ZN8cxmlutil8SetFloatERKN4cxml7ElementEPKcf
+0x933B103D cxmlutil::SetFloat(cxml::Element const&, char const*, float)
 0xC57337F8 _Fofind
 0x55A1F3B9 cellAvsetSetAudioACPInfo
 0x47433144 expm1f4fast
@@ -3333,45 +3333,45 @@
 0xF94BAA80 cellFsUnregisterL10nCallbacks
 0x46CA7FE0 cellRtcConvertLocalTimeToUtc
 0xE4416E82 cellPngDecGetsRGB
-0x91959ED6 _ZNKSt5ctypeIcE9do_narrowEcc
+0x91959ED6 std::ctype<char>::do_narrow(char, char) const
 0xBC00D5EF cellSysutilSharedMemoryFree
 0x2F2C6B3E sceNpProfileAbortGui
 0x1BFBE848 FT_New_Memory_Face
-0x0D4290D2 _ZNSt12length_errorD0Ev
+0x0D4290D2 std::length_error::~length_error()
 0xC04A7D42 cellPrintEndJob
 0x8B894DB2 ATEclose
 0x860B1756 sceNpLookupTitleSmallStorageAsync
-0x723DB220 _ZNK3paf6PhFont11GetCharInfoENS0_9GlyphTypeEtPNS0_10BitmapInfoEPi
+0x723DB220 paf::PhFont::GetCharInfo(paf::PhFont::GlyphType, unsigned short, paf::PhFont::BitmapInfo*, int*) const
 0x4C7DC863 iswupper
 0x20FA6FB7 cellMgVideoNetBindLicense
 0x42AA294E cellMarlinDLExecActivation
 0x0BEDF77D UCS2toGB18030
 0xF41355F9 wcscpy
-0x816D716B _ZN19MmsDbEditableSchema8AddFieldEPK14MmsDbFieldDataPj
+0x816D716B MmsDbEditableSchema::AddField(MmsDbFieldData const*, unsigned int*)
 0xC3277EF4 sceNpMatching2GetRoomMemberDataInternalVsh
 0x78429D81 putwchar
 0x62FEC3B7 cellNetAoiGetPspTitleId
-0x7606AF6F _ZN3vsh11VersionFile3GetEPS0_
+0x7606AF6F vsh::VersionFile::Get(vsh::VersionFile*)
 0xD14E784D cellVoicePausePortAll
 0xBDB2251A cellSailSourceSetDiagHandler
 0x2E09D1C4 cellAvsetSetMacrovisionCode
-0xD8B23008 _ZNSt8ios_baseD2Ev
+0xD8B23008 std::ios_base::~ios_base()
 0xC2DB09C5 sceAdAsyncSpaceClose
 0x005200E6 UCS2toEUCJP
 0x9EB084DB cellCelpEncOpenEx
 0x09DF2E43 cellExifOpenJpegFile
-0x016A3B00 _ZN3paf8PhWidget13DestroyWidgetEv
+0x016A3B00 paf::PhWidget::DestroyWidget()
 0xAF41D6C8 cellPesmInitEntry
 0xA85AED2E cellVideoPlayerTransferPicture
 0xBF0D62FD cellGcmSetReport
 0x290893FB rafStart
 0x25253FE4 cellFontSetEffectWeight
 0x0BDDE97F atx_free_encode_global_table
-0x6500D2D5 _ZNSt9money_putIwSt19ostreambuf_iteratorIwSt11char_traitsIwEEE7_GetcatEPPKNSt6locale5facetE
-0x5367AE32 _ZN3paf5PhWeb16SetCharactorSizeEi
+0x6500D2D5 std::money_put<wchar_t, std::ostreambuf_iterator<wchar_t, std::char_traits<wchar_t>>>::_Getcat(std::locale::facet const**)
+0x5367AE32 paf::PhWeb::SetCharactorSize(int)
 0x9912065D sceNpOAuthVshTerm
 0x48C001B0 cellRudpWrite
-0x0EF0A387 _ZN3paf7PhMiconD2Ev
+0x0EF0A387 paf::PhMicon::~PhMicon()
 0x371674CF cellGcmGetDisplayBufferByFlipIndex
 0xC79F8B0D gnpc_get_req_buffer_size
 0xD1A40EF4 cellPamfVerify
@@ -3382,7 +3382,7 @@
 0x04AF134E cellAudioCreateNotifyEventQueue
 0xAFC62605 sceNpUtilSetPlatformType
 0x07236C83 cellSysutilAvc2ChangeVideoResolution
-0xEB757101 _ZN3vsh18GetCooperationModeEv
+0xEB757101 vsh::GetCooperationMode()
 0x5A317E50 cellTiffDecOpen
 0xFB2BD688 _Stdout
 0x7B6FA92E cellSailPlayerReopenEsUser
@@ -3395,7 +3395,7 @@
 0x158032C9 sceNpSignalingDestroyCtxVsh
 0x657D0E83 divf4fast
 0xB4FD7E9B divx311DecReset
-0x16BBECC7 _ZN13MmsMdAccessor17DeleteMetadataSetEjPy
+0x16BBECC7 MmsMdAccessor::DeleteMetadataSet(unsigned int, unsigned long long*)
 0x2E1F7D0A FT_Raccess_Get_HeaderInfo
 0x93678562 sceSdSetMember
 0x9D6AF72A cellMsgDialogProgressBarSetMsg
@@ -3418,49 +3418,49 @@
 0xDC09357E cellGcmSetFlip
 0xEFFE5A16 sceNpMatching2GetLobbyMemberIdListLocal
 0x608212FC sys_mempool_free_block
-0xEB017934 _ZNK9PSJSValue7ToFloatEv
+0xEB017934 PSJSValue::ToFloat() const
 0xBB6C0EB2 cellHttpClientSetSendBufferSize
 0xA37FED15 cellSailFutureSet
 0x65F7338B cellPesmEncryptSample
-0x2070A73D _ZNSt6locale7_LocimpC1ERKS0_
+0x2070A73D std::locale::_Locimp::_Locimp(std::locale::_Locimp const&)
 0xEFEDD836 cellGcmSetTextureControlAlphaKill
 0x3457C0DB sceNpMatching2GetServerInfo
-0xB47470E1 _ZN16sysutil_cxmlutil11FixedMemory5BeginEi
+0xB47470E1 sysutil_cxmlutil::FixedMemory::Begin(int)
 0x8EAF47A3 cellHttpClientSetAutoAuthentication
-0xCC79F55D _ZNKSt7_MpunctIcE16do_negative_signEv
+0xCC79F55D std::_Mpunct<char>::do_negative_sign() const
 0xE1C71B05 ccoshl
-0x3A5DB54E _ZN3paf6PhSpin12SetShowStateEi
+0x3A5DB54E paf::PhSpin::SetShowState(int)
 0x9C4C131A cellMp3EncEndSeq
 0xA2720DF2 cellSysutilPacketWrite
 0x24FA3789 cellApostSrcProcessHandle
 0xC9030138 cellMouseInit
-0x44F95B67 _ZN3paf11PhLabelPrimC1EPNS_8PhWidgetEPNS_8PhAppearE
+0x44F95B67 paf::PhLabelPrim::PhLabelPrim(paf::PhWidget*, paf::PhAppear*)
 0x04E83D2C _sys_strncmp
 0x5A59E258 cellSysmoduleIsLoaded
-0x5560C79E _ZNSdD1Ev
+0x5560C79E std::basic_iostream<char, std::char_traits<char>>::~basic_iostream()
 0x6B6AB2A9 _LDclass
-0x2BD8F812 _ZN3paf8PhCanvas4lockEv
+0x2BD8F812 paf::PhCanvas::lock()
 0x5909E3C4 memset
-0x0C16A258 _ZN3paf7PhPlaneD2Ev
+0x0C16A258 paf::PhPlane::~PhPlane()
 0x0891A3FA _Tlsfree
-0xEBD30F24 _ZN3paf6ThreadD2Ev
+0xEBD30F24 paf::Thread::~Thread()
 0x98146E83 cellAvsetSetAudioInactive
 0x22A36B23 cellSysutilAvcExtGetWindowPosition
 0xA3501595 cellDSEEGetVersion
 0xD12673A0 FT_Set_Pixel_Sizes
 0x416CDBC4 ft_glyphslot_alloc_bitmap
-0xDB5EAE26 _ZNSt13basic_filebufIcSt11char_traitsIcEE5_InitEPSt6_FiletNS2_7_InitflE
-0x151D5C78 _ZmlRK4vec4S1_
+0xDB5EAE26 std::basic_filebuf<char, std::char_traits<char>>::_Init(std::_Filet*, std::basic_filebuf<char, std::char_traits<char>>::_Initfl)
+0x151D5C78 operator* (vec4 const&, vec4 const&)
 0xA65886B8 _Findloc
-0x1B087988 _ZN3paf8PhXmList16UpdateLabelColorEv
+0x1B087988 paf::PhXmList::UpdateLabelColor()
 0xABE090E3 cellUsbPspcmBind
-0x9B5358F9 _ZNKSt7_MpunctIcE16do_positive_signEv
-0x19840447 _ZN3paf8PhXmItem8FocusOutEff
+0x9B5358F9 std::_Mpunct<char>::do_positive_sign() const
+0x19840447 paf::PhXmItem::FocusOut(float, float)
 0x8B33F863 cellPngDecExtReadHeader
 0x68BA4568 _cellFiberPpuUtilWorkerControlAttributeInitialize
 0xA15F35FE sceNpBasicGetPlayersHistoryEntryCount
 0x7AF7A874 _cellGcmFunc21
-0x698E01BE _ZN3paf7Surface11GetPageSizeEii9ImageMode10ImageOrder
+0x698E01BE paf::Surface::GetPageSize(int, int, ImageMode, ImageOrder)
 0x015910A0 Pool_Destroy
 0x28115589 sceNpSignalingTerminateConnectionVsh
 0x2C272C13 FT_Raccess_Guess
@@ -3481,7 +3481,7 @@
 0x9D792718 FTFaceH_SetCompositeCodes
 0x954F48F8 cellSailRendererVideoNotifyCallCompleted
 0xF8115D69 cellGameRegisterDiscChangeCallback
-0x2C4E7D1C _ZN3paf4View9InitParamC1Ev
+0x2C4E7D1C paf::View::InitParam::InitParam()
 0xA146A143 sys_mempool_allocate_block
 0x7F4677A8 cellFsUnlink
 0xDB615095 FT_Done_Glyph
@@ -3490,14 +3490,14 @@
 0xDE509EAD cellPhotoExportProgress
 0xA4CA5CF2 llroundf
 0x1A0DE550 cellGcmSetCursorPosition
-0x11DE1214 _ZN3paf5Image4LoadEb
+0x11DE1214 paf::Image::Load(bool)
 0x1E29103B cellImeJpConvertForward
 0xEBEA23A1 sceNetHttpXmlConsoleInfoBitOpe
-0xE5E1DCBC _ZNSt15basic_streambufIwSt11char_traitsIwEE5imbueERKSt6locale
+0xE5E1DCBC std::basic_streambuf<wchar_t, std::char_traits<wchar_t>>::imbue(std::locale const&)
 0xADD67C35 pafGuColor4f
 0xC357B33A frexpl
-0x7CA3EE8E _ZNK7bXCeDoc7GetRootEv
-0x02F901C5 _ZN3vsh3fim4termEv
+0x7CA3EE8E bXCeDoc::GetRoot() const
+0x02F901C5 vsh::fim::term()
 0xA95951FC cellGcmFinish
 0x433FE2A9 fwscanf
 0x7EBFEDD9 CEComGetThreadContext
@@ -3505,7 +3505,7 @@
 0x0DCB4FF2 epsonPrintGetPrintParam
 0x8C85369B _f_fminf
 0x339A7508 cellFsUtilityForceUmount
-0xDD935969 _ZN3Ime21imeSingleInputContext7getThisEv
+0xDD935969 Ime::imeSingleInputContext::getThis()
 0x9598D4B3 cellRtcSetDosTime
 0xD666931F cellRudpGetLocalInfo
 0xF8418255 cellPngEncCoreDestroy
@@ -3519,70 +3519,70 @@
 0x67D1406B __ctype_ptr
 0x6F2104F3 cellMusicFinalize
 0xC9157D30 _sys_net_h_errno_loc
-0x210ACA5B _ZN17xCBResultIteratorC2EP16_xCore_InterfaceP4xMMSPvj17_xCB_IteratorType
+0x210ACA5B xCBResultIterator::xCBResultIterator(_xCore_Interface*, xMMS*, void*, unsigned int, _xCB_IteratorType)
 0x3FEF8AC9 PAF_Resource_DOMGetNodeNext
 0xA6DC25D1 cellFontSetupRenderEffectWeight
 0xB1D5806A pafGuCgReleaseVertexShader
-0x022BF05A _ZN3paf6PhFont8SetStyleERKNS_11PhFontStyleE
+0x022BF05A paf::PhFont::SetStyle(paf::PhFontStyle const&)
 0xB1BD7A61 sys_rsxaudio_close_connection
 0xE2F14DCF cellFontStatic
 0x41FFD4F2 sceNpScoreGetClansMembersRankingByNpIdPcId
-0x4148E091 _ZNKSt9money_getIwSt19istreambuf_iteratorIwSt11char_traitsIwEEE8_GetmfldERS3_S5_bRSt8ios_base
+0x4148E091 std::money_get<wchar_t, std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>>::_Getmfld(std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>&, std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>&, bool, std::ios_base&) const
 0x4E2EE031 cellSync2SemaphoreGetCount
 0x834F5917 ccosh
 0xC477C0F6 f_lroundf
 0xB2702E15 wcrtomb
 0xCCCD3257 cellSpudllGetImageSize
 0x596F0A56 cellPhotoDecodeInitialize
-0xD1B043B7 _ZSt10_MaklocchrIwET_cPS0_RKSt7_Cvtvec
+0xD1B043B7 wchar_t std::_Maklocchr<wchar_t>(char, wchar_t*, std::_Cvtvec const&)
 0x01D59A4E PAF_Resource_GetWidgetNodeByID
-0xEB76301C _ZNSt15basic_streambufIcSt11char_traitsIcEE9pbackfailEi
+0xEB76301C std::basic_streambuf<char, std::char_traits<char>>::pbackfail(int)
 0x4A5EAB63 cellSpursWorkloadAttributeSetName
 0x8AF3825E inet_pton
 0xCA87F652 cellDtcpIpMoveRead
-0xE75F9969 _ZN3paf6PhText8LineDownEj
+0xE75F9969 paf::PhText::LineDown(unsigned int)
 0x1A04A7B1 sceNpLogin
 0x7B7E9137 sceNpScoreGetClansRankingByRangeAsync
 0xA5BC0E19 getchar
 0xA84FBC36 cellPesmGetSinf
 0x54B383BC _Locvar
 0x867F7B8B ToEucJpUpper
-0x4A799510 _ZNKSt7num_getIcSt19istreambuf_iteratorIcSt11char_traitsIcEEE6do_getES3_S3_RSt8ios_baseRNSt5_IosbIiE8_IostateERl
+0x4A799510 std::num_get<char, std::istreambuf_iterator<char, std::char_traits<char>>>::do_get(std::istreambuf_iterator<char, std::char_traits<char>>, std::istreambuf_iterator<char, std::char_traits<char>>, std::ios_base&, std::_Iosb<int>::_Iostate&, long&) const
 0x1906CE6B jstrnchk
-0xC193AEFD _ZNK3paf10PhSaveData13IsPS2SaveDataEv
+0xC193AEFD paf::PhSaveData::IsPS2SaveData() const
 0xC3E14CBE memcmp
 0x6DE4B508 ToSjisUpper
 0x19109EC7 cellCryptoPuRsaesPkcs1v15Enc512
 0xC20A2975 FT_Stroker_GetCounts
 0x969FC5F7 cellJpgEncClose
-0x23AFB290 _ZNK3paf4View12GetInterfaceEi
+0x23AFB290 paf::View::GetInterface(int) const
 0x8AC398F1 cellRudpPollDestroy
-0xD75F6183 _ZN3paf8PhWidget11RemoveChildEi
+0xD75F6183 paf::PhWidget::RemoveChild(int)
 0x4D40CF98 cellHttpClientGetProxy
 0x5A4AB223 MSJISstoUTF8s
 0xF8244C5E FTManager_Init_FreeType
-0xA3224451 _ZN3paf11PhLabelText14SetLineVisibleEjb
-0xCB82E0DC _ZSt13set_terminatePFvvE
+0xA3224451 paf::PhLabelText::SetLineVisible(unsigned int, bool)
+0xCB82E0DC std::set_terminate(void (*)())
 0x7125FEB5 xSettingMusicGetInterface
 0x2AD091C6 UCS2stoUTF8s
 0x529231B0 cellSaveDataUserFixedImport
 0x3D1760DC sceNpLookupAbortTransaction
 0xDBF70550 cellMusicDecodeGetSelectionContext
 0x9003AE80 bXCeMemInitialize
-0xC2B49A34 _ZN20MmsMdImporterManager15timeToMmsDbDateExPx
+0xC2B49A34 MmsMdImporterManager::timeToMmsDbDate(long long, long long*)
 0x13EFE7F5 getsockname
 0x05709BBF cellMicOpenEx
 0x8E8BC444 cellVideoOutRegisterCallback
-0xD78EFCC3 _ZNSt12strstreambuf9underflowEv
+0xD78EFCC3 std::strstreambuf::underflow()
 0xFFB9562B cellGcmSetZcullEnable
-0x0E6B6616 _ZN10psjsvectorC1EjPf
+0x0E6B6616 psjsvector::psjsvector(unsigned int, float*)
 0xDA0EB71A sys_lwcond_create
-0x2B86EEC6 _ZN3paf8PhWidget20SetMetaAlpha_ontimerEfb
+0x2B86EEC6 paf::PhWidget::SetMetaAlpha_ontimer(float, bool)
 0xBF022284 cellSysutilAvc2LeaveChat
 0x8C3337BC sceNpFbUtilDestroyTransaction
 0xE97C9BD4 cellPngDecSetParameter
 0xDB42EEE6 cellM4vEncOpenExt
-0xBA7437D9 _ZN8cxmlutil8GetIDRefERKN4cxml7ElementEPKcPS5_PS1_
+0xBA7437D9 cxmlutil::GetIDRef(cxml::Element const&, char const*, char const**, cxml::Element*)
 0x2D96313F cellSysutilPacketRead
 0x0DFBADFA cellKey2CharSetArrangement
 0x3F9DC158 cellAvsetSetPortOption
@@ -3590,7 +3590,7 @@
 0xDBE84071 sceNpMatching2SignalingGetPeerNetInfo
 0xA6D0376F ATEdrive
 0xA29CA82E FT_Get_X11_Font_Format
-0x020B22F3 _ZNKSt7num_putIwSt19ostreambuf_iteratorIwSt11char_traitsIwEEE6do_putES3_RSt8ios_basewPKv
+0x020B22F3 std::num_put<wchar_t, std::ostreambuf_iterator<wchar_t, std::char_traits<wchar_t>>>::do_put(std::ostreambuf_iterator<wchar_t, std::char_traits<wchar_t>>, std::ios_base&, wchar_t, void const*) const
 0x735770D1 sceNpMatching2JoinLobbyVsh
 0x65E27CB3 FTFaceH_GetGlyphImage
 0x6BA10474 _Tlsalloc
@@ -3599,43 +3599,43 @@
 0x6CE8408E cellGcmSetFogMode
 0x739C2F63 cellSysutilAvcExtHideWindow
 0x480886AF cellNetAoiInit
-0xA433147A _ZNSt8messagesIcE7_GetcatEPPKNSt6locale5facetE
+0xA433147A std::messages<char>::_Getcat(std::locale::facet const**)
 0x45652CFD smf_ApPs_GetMediaTimeScale
-0x3BAC19DC _ZThn8_NSdD0Ev
+0x3BAC19DC non-virtual thunk to std::basic_iostream<char, std::char_traits<char>>::~basic_iostream()
 0x764EC2D2 cellSailSourceNotifyCallCompleted
 0x808E665F ft_mem_qalloc
-0xBF9C3609 _ZNKSt5ctypeIwE10do_toupperEPwPKw
+0xBF9C3609 std::ctype<wchar_t>::do_toupper(wchar_t*, wchar_t const*) const
 0x4E0B69EE cellMicGetFormatRaw
 0x8FB7BAC7 _sqrtf4fast
 0xF5A32994 _Getpcostate
-0x19959D90 _Z19xcbReferRecordValuePvPhPS_
+0x19959D90 xcbReferRecordValue(void*, unsigned char*, void**)
 0xFE9A658C cellCryptoPuRegPrngFunc
 0xCAFD4F96 cellAsfParser2SeekTime
 0x42332CB7 sceNpClansTerm
 0x35B6E70A lrintl
-0x6863452E _ZNSt6locale5facetD1Ev
+0x6863452E std::locale::facet::~facet()
 0x103D6B46 cellSysutilAvc2GetWindowAttribute
-0xD0197A7D _ZN3paf7PhPlaneC1EPNS_8PhWidgetEPNS_8PhAppearE
+0xD0197A7D paf::PhPlane::PhPlane(paf::PhWidget*, paf::PhAppear*)
 0x0CFB527B cellGcmSetRestartIndex
 0x47BB3BC0 cellMinisSaveDataSingleDelete
 0xF8467DE2 SSL_get_current_cipher
-0x58DEE636 _ZN4xMMS19GetFieldInformationEPvjP22xMMSFieldInformation_t
-0x53D68A12 _ZN3paf7WebCore13IsInitializedEv
+0x58DEE636 xMMS::GetFieldInformation(void*, unsigned int, xMMSFieldInformation_t*)
+0x53D68A12 paf::WebCore::IsInitialized()
 0x459B4393 _sys_strcmp
 0xF4207734 spu_thread_write_ulong
 0xF77967F6 cellMtpResetDevice
 0x29F51030 FTFaceH_GetRenderEffectWeight
-0xB401D9AD _ZNK4cxml8Document7GetSizeEv
+0xB401D9AD cxml::Document::GetSize() const
 0x5659DA82 cellSpursJobQueueGetMaxSizeJobDescriptor
-0x52692705 _ZN3vsh10ScrollTextD1Ev
+0x52692705 vsh::ScrollText::~ScrollText()
 0x44328AA2 sys_net_close_dump
 0x60E9FF3C _expm1f4
 0x065B610D sceNpTusSetMultiSlotVariableAsync
 0x13D56523 sceNpCommerceGetDataFlagAbortVsh
-0x1877A414 _ZNK3paf10PhSaveData15GetRotationRateEv
+0x1877A414 paf::PhSaveData::GetRotationRate() const
 0x9DB68B9D cellGcmSetDrawInlineIndexArray16
 0x2BBB6B52 smf_FSeek
-0x746C5F88 _ZN3vsh16GetString_OptionEv
+0x746C5F88 vsh::GetString_Option()
 0x118712EA islower
 0x664E04B9 negatef4
 0x3BD53C7B _sys_memchr
@@ -3643,22 +3643,22 @@
 0xC0EB9266 sys_dbg_finalize_ppu_exception_handler
 0x52911BCF cellDmuxQueryEsAttr2
 0x38DADF1F sceNpClansGetAutoAcceptStatus
-0xD62A98D0 _ZN13bXCeXMLParser7DestroyEv
+0xD62A98D0 bXCeXMLParser::Destroy()
 0xBC8C081D FTC_ImageCache_New
 0x027BB79D sceNetUpnpInit
-0x1374B8C8 _ZNSt10moneypunctIcLb0EED1Ev
+0x1374B8C8 std::moneypunct<char, false>::~moneypunct()
 0xA183EA88 atxenc_cmode_to_channels
 0x14358CCC cellVideoPlayerGetAudioTrackInfo
 0x23134710 cellRescSetDisplayMode
-0xD7D92E51 _ZNSt9money_putIcSt19ostreambuf_iteratorIcSt11char_traitsIcEEED0Ev
+0xD7D92E51 std::money_put<char, std::ostreambuf_iterator<char, std::char_traits<char>>>::~money_put()
 0xFFAF9B19 xSettingKbdGetInterface
 0x47B43DD4 cellImeJpOpen2
 0x17348BA6 _QN4cell5Daisy9_snprintfEPcjPKcz
 0x1851073A mios2_Client_VirtualDestroy
 0x55F6921C UCS2stoGBKs
 0xD9956CE7 sceNpCommerce2GetGameProductInfoFromGetProductInfoListResult
-0xF7D65DC1 _ZN3paf9PhHandler16HandleFocusEventEPNS_7PhEventE
-0xA6525AE6 _ZN3vsh10OptionMenu10CloseChildEPN3paf4ViewE
+0xF7D65DC1 paf::PhHandler::HandleFocusEvent(paf::PhEvent*)
+0xA6525AE6 vsh::OptionMenu::CloseChild(paf::View*)
 0xAC98B03A sceNpMatching2GetUserInfoList
 0xC17259DE cellFontGenerateCharGlyph
 0xC141037D FT_Get_PFR_Kerning
@@ -3666,27 +3666,27 @@
 0x1714D098 cellFsUtilGetMountInfoSize
 0x43DDAB4F cellSpursJobQueueAttributeInitialize
 0xA48BE428 cellSailMp4TrackGetTrackInfo
-0x4986187C _ZN8cxmlutil16CheckElementNameERKN4cxml7ElementEPKc
+0x4986187C cxmlutil::CheckElementName(cxml::Element const&, char const*)
 0xB56EF5A1 cellAudioSetNotifyEventQueueEx
-0x67948307 _ZNKSt7codecvtIwcSt9_MbstatetE9do_lengthERKS0_PKcS5_j
+0x67948307 std::codecvt<wchar_t, char, std::_Mbstatet>::do_length(std::_Mbstatet const&, char const*, char const*, unsigned int) const
 0xB422B005 cellFontRenderSurfaceSetScissor
 0x1BA194A2 cellVoiceDebugCpuUsage
-0x1E5B1E23 _ZN4cell5Daisy22ScatterGatherInterlockC1EPVNS0_16_AtomicInterlockEjPjjh
+0x1E5B1E23 cell::Daisy::ScatterGatherInterlock::ScatterGatherInterlock(cell::Daisy::_AtomicInterlock volatile*, unsigned int, unsigned int*, unsigned int, unsigned char)
 0xD9A4F812 atoff
 0x85A969B6 FT_Init_FreeType
 0x172C3197 cellGcmSetDefaultCommandBufferAndSegmentWordSize
-0x6B913D53 _ZNSs6insertEjjc
+0x6B913D53 std::basic_string<char, std::char_traits<char>, std::allocator<char>>::insert(unsigned int, unsigned int, char)
 0x811D148E _cellSyncLFQueueDetachLv2EventQueue
 0xBD5A59FC cellNetCtlInit
-0xE3EDD790 _ZNSt8bad_castD1Ev
-0xA67B323A _ZN3vsh3fim7destroyEv
-0x7882E64E _ZNSt7collateIwED0Ev
+0xE3EDD790 std::bad_cast::~bad_cast()
+0xA67B323A vsh::fim::destroy()
+0x7882E64E std::collate<wchar_t>::~collate()
 0x5ED42691 sceNetApCtlGetStateVsh
 0x2E86164D _cellSslConvertCipherId
-0x20DC18B5 _ZN3paf7PhMiconD0Ev
+0x20DC18B5 paf::PhMicon::~PhMicon()
 0xD8EA91F8 cellJpgDecDestroy
 0x89456724 cellSysutilAvc2InitParam
-0xEDD39FD7 _ZN3paf10PhSaveData8SetFrameEf
+0xEDD39FD7 paf::PhSaveData::SetFrame(float)
 0x9458F464 sceNpCustomMenuRegisterExceptionList
 0x2B84030C EUCKRstoUTF8s
 0x5A74F774 spu_thread_read_float
@@ -3696,10 +3696,10 @@
 0xE28B206B cellCameraReadComplete
 0x6F0B1002 cellSailPlayerSubscribeEvent
 0x934ABB00 cellSpursJobQueuePort2AllocateJobDescriptor
-0xD6A50AAC _ZN3paf10PhItemSpinC2EPNS_8PhWidgetEPNS_8PhAppearE
-0xE177FD02 _ZNSt7_MpunctIcED2Ev
+0xD6A50AAC paf::PhItemSpin::PhItemSpin(paf::PhWidget*, paf::PhAppear*)
+0xE177FD02 std::_Mpunct<char>::~_Mpunct()
 0xEB40C9EC rand_real2_TT800
-0x668B31C6 _ZNSs5_GrowEjb
+0x668B31C6 std::basic_string<char, std::char_traits<char>, std::allocator<char>>::_Grow(unsigned int, bool)
 0x05E27A13 log10f4fast
 0x0B9D04D0 _Getnloc
 0xD87822AB cellM4vEncCancelStream
@@ -3712,7 +3712,7 @@
 0x6AD1C42B _sincosf4
 0x9BB876F4 SSL_CIPHER_get_bits
 0xE6C43C58 cellOskDialogExtEnableHalfByteKana
-0xA499E2BE _ZNK3paf4View10GetTextureEPv
+0xA499E2BE paf::View::GetTexture(void*) const
 0x20F438AD FT_SqrtFixed
 0xFF0FA43A cellVoiceResetPort
 0x99AB1A26 cellGameUpdateInit
@@ -3721,24 +3721,24 @@
 0x8B9AAD3E PAF_Resource_DOMGetNodeType
 0x5E662299 canonPrintSendBand
 0x4E72F810 wmemchr
-0x8A9529BA _ZN3paf10HeapMemory16dump_sysmem_infoEPKcS2_i
+0x8A9529BA paf::HeapMemory::dump_sysmem_info(char const*, char const*, int)
 0xFD6A1DDB raw_spu_read_llong
 0x266D2473 _Caddcr
 0x408A622B ToEucJpHira
 0x18F7B77D _Dnorm
 0x90E9B5D2 EUCJPstoUCS2s
-0x0BA5483C _ZNKSt12codecvt_base11do_encodingEv
+0x0BA5483C std::codecvt_base::do_encoding() const
 0x3AB9A95E module_exit
-0x6D88479C _ZN8XMWIOCTL10DisconnectEv
+0x6D88479C XMWIOCTL::Disconnect()
 0xFB932A56 atan2f
 0x4B36C0E0 vfscanf
-0xBC0F8BCA _ZN3vsh16GetReleaseTargetEv
+0xBC0F8BCA vsh::GetReleaseTarget()
 0xB3EB7AFB dlnaPrintGetString
 0xDD3D7EC0 cellVideoPlayerSetTransferComplete
 0x01ECEF7D _FCbuild
 0xD0EBD14F cellSailComposerGetEsAudioParameter
 0xA1ECA254 cellGcmSetShadeMode
-0x983EA578 _ZN3paf7PhSText8SetStyleEii
+0x983EA578 paf::PhSText::SetStyle(int, int)
 0x5A0355CF smvd2SetDecodeMode
 0xDB869F20 cellFsAioInit
 0x67E805C3 cellFontsetUSleep
@@ -3749,20 +3749,20 @@
 0xEBA8D4EC cellSailPlayerStop
 0x42439DB5 cellOskDialogExtSendFinishMessage
 0xF1DCFA71 UCS2stoUHCs
-0x7E7AC30E _ZNSt6locale5emptyEv
+0x7E7AC30E std::locale::empty()
 0xF89DC648 strpbrk
-0x332F8409 _ZNSt8time_putIcSt19ostreambuf_iteratorIcSt11char_traitsIcEEE7_GetcatEPPKNSt6locale5facetE
-0x5A6E4E50 _ZNSt6locale7_Locimp9_MakewlocERKSt8_LocinfoiPS0_PKS_
+0x332F8409 std::time_put<char, std::ostreambuf_iterator<char, std::char_traits<char>>>::_Getcat(std::locale::facet const**)
+0x5A6E4E50 std::locale::_Locimp::_Makewloc(std::_Locinfo const&, int, std::locale::_Locimp*, std::locale const*)
 0x233791FE cellFsUtilNewfs
 0x07DAED62 log2f4
 0xF0C371A5 _cellGcmFunc5
-0x9AEFF88B _ZN3paf8PhWidget6LookAtERK4vec4S3_
+0x9AEFF88B paf::PhWidget::LookAt(vec4 const&, vec4 const&)
 0xBAFD6409 cellPadLddDataInsert
-0x08E1865C _ZNKSt8numpunctIwE16do_thousands_sepEv
+0x08E1865C std::numpunct<wchar_t>::do_thousands_sep() const
 0x00582E1A cellGcmSetPointSpriteControl
 0xE34A25C8 SSL_get_error
 0x368FEC59 sceNpTusGetMultiUserDataStatusVUserAsync
-0x31573F9A _ZN3vsh10ScrollText5StartEv
+0x31573F9A vsh::ScrollText::Start()
 0x34E2588C xAutoMounterGetInstance
 0x09C0E1F1 cellGcmSetWaitForIdle
 0xC35ED665 cellSysutilAvc2SetSpeakerMuting
@@ -3771,13 +3771,13 @@
 0x92B50EBC cellMusicExportProgress
 0x63BBDFA6 _FCmulcc
 0xC7781115 cellCryptoPuSha256Hash
-0x02E40598 _ZNSt8time_getIwSt19istreambuf_iteratorIwSt11char_traitsIwEEE5_InitERKSt8_Locinfo
+0x02E40598 std::time_get<wchar_t, std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>>::_Init(std::_Locinfo const&)
 0xBEF554A4 cellFsUtime
 0x89C9917C sys_net_read_dump
-0x0E9A5554 _ZNSt13basic_istreamIwSt11char_traitsIwEED0Ev
+0x0E9A5554 std::basic_istream<wchar_t, std::char_traits<wchar_t>>::~basic_istream()
 0xCF3051F7 cellPadDbgGetData
 0xD38ACB22 cellAsfGetNonStreamObjectInfo
-0x9A194306 _ZNSt8time_getIcSt19istreambuf_iteratorIcSt11char_traitsIcEEE5_InitERKSt8_Locinfo
+0x9A194306 std::time_get<char, std::istreambuf_iterator<char, std::char_traits<char>>>::_Init(std::_Locinfo const&)
 0x3545BDC1 FT_Load_Sfnt_Table
 0xEB8ABE73 vwscanf
 0xE18C273C cellSyncLFQueueDepth
@@ -3787,14 +3787,14 @@
 0x2FECEC13 getwchar
 0x41B4A5AE UHCstoUCS2s
 0x6E988E5F _rand_int31_TT800
-0x79AD3575 _ZTv0_n12_NSoD1Ev
+0x79AD3575 virtual thunk to std::basic_ostream<char, std::char_traits<char>>::~basic_ostream()
 0xBA39AB02 cellPesmEndMovieRec
 0x46356FE0 _cellSyncLFQueueGetPopPointer2
 0xF3EC0258 round
 0xFFDEAFDB scePS2McIconSys_GetIconFileName
 0x0B017E2B _sce_net_add_name_server
 0xB7AB5127 wcsrchr
-0x83531F72 _ZN13PSJSValueImpl11NewFromPoolERK11PSJSContext
+0x83531F72 PSJSValueImpl::NewFromPool(PSJSContext const&)
 0x5C95DF57 cellNetCtlMintXGetInfo
 0x65E8D4D0 wcslen
 0xE6DE720D FT_GlyphLoader_New
@@ -3804,7 +3804,7 @@
 0xCFFC42A5 cellVdecSetFrameRateExt
 0xC76BC1B4 cellCameraOpenAsync
 0xA26AA437 cellSysutilAvc2IsMicAttached
-0xCFAD36DE _ZN4cxml8DocumentC1Ev
+0xCFAD36DE cxml::Document::Document()
 0xCD48AD62 cellCelp8EncOpenEx
 0xBDD44EE3 SJIStoUCS2
 0xF514EDF3 cellGcmCgGetParameterResource
@@ -3812,28 +3812,28 @@
 0x0E63C444 cellCameraGetBufferInfoEx
 0x8F6E2CA0 cellVdecGetPicItemEx
 0xE2201D8B sceNpC7yTusEndVsh
-0x4D89A149 _ZNK4cxml9Attribute7GetFileEPNS_4FileE
-0x3A8454FC _ZNK3paf4View10GetTextureEPKc
+0x4D89A149 cxml::Attribute::GetFile(cxml::File*) const
+0x3A8454FC paf::View::GetTexture(char const*) const
 0xA7C066DE cellSpursJoinJobChain
 0xD9CD56BA svc1dReleaseInstance
 0x4357C77F cellPhotoExportInitialize
 0x7E8B6001 naacEncGetPce
 0x7D4375EB sjvtdCancelDecode
 0x99040A1D FT_Remove_Module
-0x4F381F53 _ZmlRK4vec4f
+0x4F381F53 operator* (vec4 const&, float)
 0xED6EC979 fsetpos
 0x4D866CF0 divxDecGetPicture
 0xF4A52EC2 cellMtpInit
-0x5232FAAF _Z7inverseRK4mat4
-0x24A977F7 _ZN3paf8PhWidget9PauseAnimEb
+0x5232FAAF inverse(mat4 const&)
+0x24A977F7 paf::PhWidget::PauseAnim(bool)
 0xC62B758D UTF8stoEUCJPs
 0x496C8B70 cellAsfParser2GetPacketInfo
 0x8E258FA0 cacos
 0x2D820D7F cellAsfParser2ReadData
 0x8BB41F47 cellImeJpPostConvert
-0xDDE862B5 _ZN3paf7PhXmBar17SetOtherItemAlphaEfff
+0xDDE862B5 paf::PhXmBar::SetOtherItemAlpha(float, float, float)
 0xFEAC6F53 cellFt2dMeanVariance
-0xCCD2C319 _ZN3vsh16GetString_CancelEv
+0xCCD2C319 vsh::GetString_Cancel()
 0x1FA1B312 sceNpCommerce2GetStoreBrowseUserdata
 0x1AE8A549 sceNpBasicAddBlockListEntry
 0x52B7883F UTF8stoBIG5s
@@ -3843,10 +3843,10 @@
 0xF57D74E3 cellSailRecorderFinalize
 0xF4E0F607 sceNpScoreGetBoardInfo
 0x37E33878 FT_Trace_Get_Name
-0xB59872EF _ZN16sysutil_cxmlutil11FixedMemory8AllocateEN4cxml14AllocationTypeEPvS3_jPS3_Pj
+0xB59872EF sysutil_cxmlutil::FixedMemory::Allocate(cxml::AllocationType, void*, void*, unsigned int, void**, unsigned int*)
 0xF1446A40 cellSailPlayerSetEsVideoMuted
 0x345579CF scePS2McIconSys_Attribute
-0xCCE0FADA _ZN3paf13PhApplication15SetCustomRenderEPFvPS0_E
+0xCCE0FADA paf::PhApplication::SetCustomRender(void (*)(paf::PhApplication*))
 0x2F85C0EF sys_lwmutex_create
 0x3261DE11 fesetexceptflag
 0x07924359 cellSailPlayerCloseEsVideo
@@ -3854,14 +3854,14 @@
 0xD3964A09 __spu_thread_putfld
 0xB5C11938 cellAtracGetInternalErrorInfo
 0x06DDB53E cellAtracSetSecondBuffer
-0x833EF607 _ZN3paf8PhCanvas6unlockEPv
+0x833EF607 paf::PhCanvas::unlock(void*)
 0xBBB47CD8 cellSheapInitialize
-0x62D6BF82 _ZNSt8time_getIwSt19istreambuf_iteratorIwSt11char_traitsIwEEED1Ev
+0x62D6BF82 std::time_get<wchar_t, std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>>::~time_get()
 0x055C1970 FT_New_Size
 0x620FE2E9 msmw_LockCreate
 0x3F4CCDC7 isdigit
 0x79BA9B5C expl
-0xC6EE0260 _ZN4xMMS17GetMridFromRecordEPvPy
+0xC6EE0260 xMMS::GetMridFromRecord(void*, unsigned long long*)
 0xB6017827 sceNpLookupAvatarImage
 0x9ADAE986 SSLCERT_NAME_get_entry_count
 0x5C5994BD cellSheapFree
@@ -3869,21 +3869,21 @@
 0xFD2566B4 cellCelp8EncClose
 0xE3D63D30 npTrophyNetTitleGetFlagDataByArray
 0x5A668942 cellGcmSetDepthBounds
-0xD51B3CCE _ZN3paf7Surface6UnlockEv
-0xC6F18E84 _ZNKSt9money_getIwSt19istreambuf_iteratorIwSt11char_traitsIwEEE6do_getES3_S3_bRSt8ios_baseRNSt5_IosbIiE8_IostateERSbIwS2_SaIwEE
+0xD51B3CCE paf::Surface::Unlock()
+0xC6F18E84 std::money_get<wchar_t, std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>>::do_get(std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>, std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>, bool, std::ios_base&, std::_Iosb<int>::_Iostate&, std::basic_string<wchar_t, std::char_traits<wchar_t>, std::allocator<wchar_t>>&) const
 0x04A183FC strcpy
-0x57B6F6B2 _ZNK3paf9PhSRender8GetStyleEiRb
+0x57B6F6B2 paf::PhSRender::GetStyle(int, bool&) const
 0xE6D9E234 UTF8toBIG5
 0x3666354F svc1dCancelDecode
 0x8B6BAA01 cellFiberPpuFinalizeScheduler
 0xC406DD09 cbrtf4
 0x2BEAC488 cellAudioOutGetSoundAvailability2
 0xA1B292A4 sceFimPresenceRegisterCb
-0x1CCF9E4D _ZN3paf8SyncCallC1Ev
-0x11395765 _ZN3paf5Image7OpenGIMEPvj
+0x1CCF9E4D paf::SyncCall::SyncCall()
+0x11395765 paf::Image::OpenGIM(void*, unsigned int)
 0xCA103173 pafGuCgCreateVertexShader
 0xF476E8AA pafGuGetDrawSurfW
-0x888BE764 _ZN3vsh11ContentInfo4MenuEff
+0x888BE764 vsh::ContentInfo::Menu(float, float)
 0x21CEE035 cellGcmGetNotifyDataAddress
 0xCBA11A47 cellGcmSysSetWaitQueue
 0x17D1213B cellAudioSendAck
@@ -3891,28 +3891,28 @@
 0x8A71F49D cellDivXDrmTerm
 0x4F36CF3F FT_Get_Char_Index
 0xFB07BD72 sceNpFbUtilStreamPublishExt
-0x360F8A4F _ZNSt9money_getIcSt19istreambuf_iteratorIcSt11char_traitsIcEEED1Ev
+0x360F8A4F std::money_get<char, std::istreambuf_iterator<char, std::char_traits<char>>>::~money_get()
 0x16A8A805 xSettingBdvdGetInterface
 0xBF5F58EA sceNpCommerce2GetProductInfoGetResult
 0x4347DA4A sceNpCommerceDoCheckoutFinishVsh
 0x2664C8AE cellFsStReadInit
-0xB0C185B7 _ZNSt10moneypunctIcLb1EE7_GetcatEPPKNSt6locale5facetE
-0xF7BE0678 _Z32xcbResolveDefaultDestinationPathPvS_PcS0_
+0xB0C185B7 std::moneypunct<char, true>::_Getcat(std::locale::facet const**)
+0xF7BE0678 xcbResolveDefaultDestinationPath(void*, void*, char*, char*)
 0x62023E98 sceNpCommerce2CreateSessionAbort
 0x86B4C669 tolower_ascii
 0xC02932C4 cellCryptoPuAesDecKeySet
 0x3D0D3B72 cellSailSoundAdapterInitialize
 0xC91C8ECE cellFontGetBindingRenderer
 0x1E9D2B4F spu_thread_read_int
-0xD7BC220D _ZNSt8time_putIcSt19ostreambuf_iteratorIcSt11char_traitsIcEEED1Ev
+0xD7BC220D std::time_put<char, std::ostreambuf_iterator<char, std::char_traits<char>>>::~time_put()
 0x612F79B0 cellM4vEncGetResult2
 0x05319303 SSL_alert_desc_string_long
-0x1C3F1C4F _ZNSt6_MutexD1Ev
+0x1C3F1C4F std::_Mutex::~_Mutex()
 0x7CFD1C1F divxDecOpen
 0x1BBADA6A _cellSslPemReadPrivateKey
 0x141F1412 sceNpUtilParseJid
 0x6B6CAF26 _sys_net_lib_sync_create
-0x01AA0CEF _ZNKSt7num_getIwSt19istreambuf_iteratorIwSt11char_traitsIwEEE6do_getES3_S3_RSt8ios_baseRNSt5_IosbIiE8_IostateERx
+0x01AA0CEF std::num_get<wchar_t, std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>>::do_get(std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>, std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>, std::ios_base&, std::_Iosb<int>::_Iostate&, long long&) const
 0x3A1C8393 cellFsTruncate2
 0x7D07A1C2 UTF8toEUCCN
 0xFA28434B log2l
@@ -3923,16 +3923,16 @@
 0x28FAAA5A ilogbf4
 0xAD6A2E5B cellHttpSessionCookieFlush
 0x3C057FBD atanf
-0xF7F08CB2 _ZNK3paf7PhMicon7GetTimeEv
+0xF7F08CB2 paf::PhMicon::GetTime() const
 0x743918BD cellRemotePlaySetComparativeVolume
-0xAAE64804 _ZNSt8ios_base8_FindarrEi
+0xAAE64804 std::ios_base::_Findarr(int)
 0x9B244272 cellCelpEncWaitForOutput
 0x6D7444E6 cellWebBrowserActivate
 0x73209D59 FTFaceH_GetRenderScalePoint
 0xA72A7595 calloc
-0x76DE9B0F _ZNSt7num_putIcSt19ostreambuf_iteratorIcSt11char_traitsIcEEED1Ev
+0x76DE9B0F std::num_put<char, std::ostreambuf_iterator<char, std::char_traits<char>>>::~num_put()
 0xA2C7BA64 sys_prx_exitspawn_with_level
-0xCD33ED4F _ZNSbIwSt11char_traitsIwESaIwEEC1Ev
+0xCD33ED4F std::basic_string<wchar_t, std::char_traits<wchar_t>, std::allocator<wchar_t>>::basic_string()
 0x1D666D7A xRegistryDump_DBG
 0x4A3AF5B4 sceNpMatchingGetRoomSearchFlagVsh
 0x8793EF97 cellMusicGetSelectionContext2
@@ -3941,22 +3941,22 @@
 0xBB918CC2 cellMgVideoBindLicense
 0x857024E6 SSL_CTX_set_options
 0x55C5280D cellMarlinUtilityFinalize
-0xC47FB4B9 _ZNK3paf7PhScene9GetCameraEi
+0xC47FB4B9 paf::PhScene::GetCamera(int) const
 0xD54039CB fegettrapenable
 0x3D5730CE cellAudioInGetDeviceInfo
 0x02E7E03E cellGifDecExtDecodeData
 0xF9A7E8A5 cellSubDisplayInit
-0x5C54EEAF _ZNK3paf11SurfacePool11GetFreeSizeEv
+0x5C54EEAF paf::SurfacePool::GetFreeSize() const
 0xE8BB13FF sceNpAuthGetAuthorizationCode
 0x169A4182 sqlite3_errmsg
 0x2CD2A1AF sceNpScoreSanitizeCommentAsync
 0x95180230 _cellSpursAttributeInitialize
 0x38D5898C SSL_CTX_ctrl
-0xA28C8100 _ZN3paf9PhSRender8SetStyleEif
+0xA28C8100 paf::PhSRender::SetStyle(int, float)
 0x772E1A24 cellSsVtrmStore2
 0x5C48EDCD cellCryptoPuSha256Final
-0xD965C0BE _ZN3paf8PhScroll11SetMaxValueEf
-0x67FBABF0 _ZNKSt8time_getIcSt19istreambuf_iteratorIcSt11char_traitsIcEEE14do_get_weekdayES3_S3_RSt8ios_baseRNSt5_IosbIiE8_IostateEPSt2tm
+0xD965C0BE paf::PhScroll::SetMaxValue(float)
+0x67FBABF0 std::time_get<char, std::istreambuf_iterator<char, std::char_traits<char>>>::do_get_weekday(std::istreambuf_iterator<char, std::char_traits<char>>, std::istreambuf_iterator<char, std::char_traits<char>>, std::ios_base&, std::_Iosb<int>::_Iostate&, std::tm*) const
 0x0BF867E2 HZstoUCS2s
 0x9344D41F sceNpMatching2GrantRoomOwner
 0xCBF1758B cellFsGetDirentCount
@@ -3967,51 +3967,51 @@
 0x7AF8A37F cellRescSetRegisterCount
 0x349F1535 cellSsUmSetToken
 0xEB3B1212 FT_Outline_Reverse
-0x5A5A9107 _ZNSt6localeC2Ev
+0x5A5A9107 std::locale::locale()
 0x254289AC cellUsbdOpenPipe
 0xE0ACE309 cellDtcpIpSetEncryptedData
-0x794CEACB _ZNK3paf4View10FindWidgetEPKc
+0x794CEACB paf::View::FindWidget(char const*) const
 0x67504671 sceNpGetEntitlementById
 0x60B2101D cellAtracMultiGetVacantSize
 0xEA51ADEC smf_ApCm_SetFileDescriptor
 0x4AE8D215 cellGcmSetFlipMode
-0xCD7DCCF1 _ZN3vsh3fim35unRegistPresenceNotificationHandlerEv
-0x95AC1738 _ZN13bXCeXMLParser10InitializeEv
-0x8FA764F3 _ZNSt6_WinitC1Ev
+0xCD7DCCF1 vsh::fim::unRegistPresenceNotificationHandler()
+0x95AC1738 bXCeXMLParser::Initialize()
+0x8FA764F3 std::_Winit::_Winit()
 0xF9BFDC72 cellGcmSetCursorImageOffset
 0xA614EB27 smf_ApPs_ReadMovieRes2
 0x9F1795DF cellVpostOpenExt
 0x32C9F97C cellGcmTransferDataMode
 0x1498A072 _Cmulcr
 0x0D846D63 cellHttpCookieImportWithClientId
-0x42A615C8 _ZNK9PSJSValue8ToStringEv
-0x6080E864 _ZN11PSJSContext17SetStdOutCallbackEPFvPKtiPvES2_
-0x7982B632 _ZN3vsh3fim17getSelfPtrSceNpIdEv
-0xD4F23753 _ZN4xMMS13GetFieldIdForEPKhPj
+0x42A615C8 PSJSValue::ToString() const
+0x6080E864 PSJSContext::SetStdOutCallback(void (*)(unsigned short const*, int, void*), void*)
+0x7982B632 vsh::fim::getSelfPtrSceNpId()
+0xD4F23753 xMMS::GetFieldIdFor(unsigned char const*, unsigned int*)
 0x7EC07F08 FT_Bitmap_Copy
-0x0A4091F9 _ZN3paf6PhSpin8GetStyleEiRi
+0x0A4091F9 paf::PhSpin::GetStyle(int, int&)
 0x38750386 FTCacheStream_Init
 0xD50277AD tan
 0xCF34969C cellFsStReadGetStatus
-0xC49D8C3E _ZN3paf8PhXmItem16UpdateLabelColorEv
-0x6FC83371 _ZN4cell5Daisy4Lock18getNextTailPointerEv
+0xC49D8C3E paf::PhXmItem::UpdateLabelColor()
+0x6FC83371 cell::Daisy::Lock::getNextTailPointer()
 0x0FD3F094 FT_Stream_ReleaseFrame
 0x3CA81C76 _Iswctype
 0x22496C93 rafSetFade
 0x799473AE sce_paf_private_memalign
-0x343E0DAF _ZN11PSJSContextC1Ev
-0xAD6DBAC2 _ZNKSt7num_getIwSt19istreambuf_iteratorIwSt11char_traitsIwEEE6do_getES3_S3_RSt8ios_baseRNSt5_IosbIiE8_IostateERm
+0x343E0DAF PSJSContext::PSJSContext()
+0xAD6DBAC2 std::num_get<wchar_t, std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>>::do_get(std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>, std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>, std::ios_base&, std::_Iosb<int>::_Iostate&, unsigned long&) const
 0x532B8AAA cellCameraGetAttribute
 0xF25F197D cellSailSoundAdapterGetFormat
 0x005D0928 SSLCERT_check_private_key
 0xF52639EA cellGameBootCheck
 0x6CCBE3D6 cellImeJpEnterChar
 0x211D38B6 cellMgVideoInitTrack
-0xB902CB91 _ZN3paf8PhWidget8SetStyleEiib
+0xB902CB91 paf::PhWidget::SetStyle(int, int, bool)
 0x77B3B29A cellCelpEncOpen
 0x103B8632 cellFsAllocateFileAreaWithInitialData
 0x65CBBB16 cellJpgDecExtSetParameter
-0x8E8DB4B0 _ZN3paf8PhWidget19HandleFocusOutEventEPNS_7PhEventE
+0x8E8DB4B0 paf::PhWidget::HandleFocusOutEvent(paf::PhEvent*)
 0x04459230 cellNetCtlNetStartDialogLoadAsync
 0xB23F070A cellAtracMultiCreateDecoderExt
 0x9729B069 cellAsfInitParser
@@ -4020,22 +4020,22 @@
 0x95D0A26D sqlite3_column_int
 0x23AE55A3 cellGcmGetLastSecondVTime
 0xB2B91406 cellGcmSetTwoSideLightEnable
-0x46B2F111 _ZN13MmsMdAccessor7GetMridEP11MmsDbRecordPy
+0x46B2F111 MmsMdAccessor::GetMrid(MmsDbRecord*, unsigned long long*)
 0x745C2147 dlnaPrintEndPage
 0xF9C7D56C atxenc_free_handle
-0xF995E53F _ZN3vsh14GetString_BackEv
+0xF995E53F vsh::GetString_Back()
 0xF6016B2D divxDecReset
 0x68B630D5 cellCryptoPuAesOmac1Mode
-0x6EEE1B61 _ZN4cxml8Document16CreateFromBufferEPKvjb
+0x6EEE1B61 cxml::Document::CreateFromBuffer(void const*, unsigned int, bool)
 0x025B4974 cellSailPlayerUnregisterSource
 0x9452F4F8 sceNpCommerceGetCategoryImageURL
-0x706B947D _ZN3paf5Sound6Output19SetDefaultConfigureEv
-0x959BF279 _Z15pafGumDrawArrayiiiPKvS0_
+0x706B947D paf::Sound::Output::SetDefaultConfigure()
+0x959BF279 pafGumDrawArray(int, int, int, void const*, void const*)
 0x39DD8425 cellSaveDataUserListLoad
 0xEB41CC68 ARIBstoUCS2s
 0x3A5D726A cellGameGetParamString
 0x5F7F83AA FTC_SBitCache_Lookup
-0x2438F1A4 _ZN3vsh26ShowButtonNavigation_EnterEb
+0x2438F1A4 vsh::ShowButtonNavigation_Enter(bool)
 0xE13EF6FC cellVdecSetFrameRate
 0x481CE0E8 sceNpBasicAbortGui
 0x9CCDCC95 cellPngDecReadHeader
@@ -4044,30 +4044,30 @@
 0xF7AAA8E2 cellFontGraphicsGetLineRGBA
 0x672399A8 sceNpClansGetClanListByNpId
 0xA7FABF4D sceNpTrophyTerm
-0x5A6C0DB6 _ZN3vsh13MessageDialog10HideDeleteEv
+0x5A6C0DB6 vsh::MessageDialog::HideDelete()
 0x1BD633F8 _cellGcmFunc3
 0x29C2ACC5 cellSpursJobQueueClose
-0x753C71DB _ZNKSt7_MpunctIcE13do_pos_formatEv
+0x753C71DB std::_Mpunct<char>::do_pos_format() const
 0xADD66B5C cellHttpClientSetResponseBufferMax
 0xE74B2CB1 cellGifDecDestroy
 0xCC7A31CD sceNpTusGetMultiUserVariableAsync
 0x32C941CF cellRtcGetCurrentClock
 0x1B0B915E cellFsLsnGetCDA
 0xF3E81219 cellFiberPpuCheckStackLimit
-0x550BA039 _ZNK10PSJSObject12GetClassTypeEv
+0x550BA039 PSJSObject::GetClassType() const
 0xFD461E85 spu_thread_write_ldouble
-0x2F336853 _ZN3paf10PhSaveData12SetFrameRateEf
+0x2F336853 paf::PhSaveData::SetFrameRate(float)
 0x3D32ADD6 cellM4hdEncQueryResource
 0xC08CC0F9 cellSync2QueueEstimateBufferSize
 0x31F5196B cellSpursRemoveSystemWorkloadForUtility
 0x3AAA1BD0 cellFsLink
-0x3441B471 _ZN3paf8PhXmItemC1EPNS_8PhWidgetEPNS_8PhAppearE
+0x3441B471 paf::PhXmItem::PhXmItem(paf::PhWidget*, paf::PhAppear*)
 0x2687A127 sceNpSignalingGetCtxOpt
 0x96C2A2D9 smvd2SetAuxData
 0x9C4E9B5C cellFsUtilitySync
 0xFF8AC661 BIO_dump
 0xC0AB5CBB sceNpAuthOAuthTerm
-0x3443178E _Z17xcbSetRecordValuePvPhPKv
+0x3443178E xcbSetRecordValue(void*, unsigned char*, void const*)
 0xA830FDD8 sce_paf_private_calloc
 0x52CC6C82 cellSpursCreateTaskset
 0x39651E01 cellRecOpen
@@ -4075,23 +4075,23 @@
 0x1CF4D80A iswalpha
 0x961688D1 f_nearbyintf
 0xE9E8B32F xCore_Exit
-0xAABDBC6E _ZplRK4vec4S1_
-0x37AD4EFF _ZN7bXCeDoc7DestroyEv
+0xAABDBC6E operator+ (vec4 const&, vec4 const&)
+0x37AD4EFF bXCeDoc::Destroy()
 0x9F4BEB25 SSL_write
 0x012D0A91 _fminf4
 0x0D9C65BE cellHttpClientGetAllHeaders
 0x3442CB43 cellAvcEncSmallCancelStream
-0xB624302F _ZN3paf6PhList12PushBackItemEi
+0xB624302F paf::PhList::PushBackItem(int)
 0x76488BB1 cellSailGraphicsAdapterFinalize
 0x4D249136 cellMediatorGetUserInfo
 0x3ADC01D7 f_frexpf
 0x1686957E cellSpursJobQueueAttributeSetMaxSizeJobDescriptor
-0x06BC5B51 _ZNKSt7_MpunctIwE16do_positive_signEv
+0x06BC5B51 std::_Mpunct<wchar_t>::do_positive_sign() const
 0x14D58C7A cellFsMappedAllocate
-0xD64EDE7C _ZN3paf6PhList10WidgetTypeEv
+0xD64EDE7C paf::PhList::WidgetType()
 0x7D32C4D3 smf_ApPs_GetMediaDuration
 0xBABF714B cellFiberPpuUtilWorkerControlWakeup
-0x8BF263CE _ZN8psjsnameC1ERK11PSJSContextPKt
+0x8BF263CE psjsname::psjsname(PSJSContext const&, unsigned short const*)
 0x8D79A5F9 FT_Get_PS_Font_Info
 0x83490423 mios2_Client_SharedMemoryAllocate
 0xDE6AFC37 cellSysutilAvc2HideWindow
@@ -4104,11 +4104,11 @@
 0x7B9C592E spu_thread_read_ullong
 0x02E68D44 _f_fmodf
 0xD5263DEA cellUsbdGetThreadPriority
-0xF7B61EE3 _ZNK3paf7PhSPrim8GetStyleEiRf
+0xF7B61EE3 paf::PhSPrim::GetStyle(int, float&) const
 0xBF8EE5BB sys_process_spawn_with_memory_budget
 0xC938C83A ft_mem_qrealloc
-0xD314EF39 _ZN3paf8PhWidget8GetStyleEiR4mat4
-0xD88051BD _Z25PSJS_BuildValueImpl_ErrorRK11PSJSContext19PSJS_EXCEPTION_TYPEPKc
+0xD314EF39 paf::PhWidget::GetStyle(int, mat4&)
+0xD88051BD PSJS_BuildValueImpl_Error(PSJSContext const&, PSJS_EXCEPTION_TYPE, char const*)
 0x4D1E9373 cellSpursEventFlagGetClearMode
 0x9CBCE3F2 sceNpMatching2CreateContext
 0x61FB9442 UTF8toUTF16
@@ -4117,17 +4117,17 @@
 0xABDCCC7A f_atan2f
 0xD09740F6 smvd2GetMemorySize2
 0x9FDD0A84 cellAsfParser2AStdSkipFrameData
-0x56D3D4F0 _ZNSt9bad_allocD1Ev
-0x97D7BF2A _ZN3paf6Thread5StartEv
+0x56D3D4F0 std::bad_alloc::~bad_alloc()
+0x97D7BF2A paf::Thread::Start()
 0x42332FFA sceNpC7yScoreGetBoardInfoResultVsh
 0x464FF889 cellHttpResponseGetContentLength
 0xBEF53A2B cellVoiceGetBitRate
 0xEBBFEAC3 svc1dGetSideInfoSeq
 0xF8206492 cellSslCertGetPublicKey
-0x78C2B936 _ZNK3paf10PhSaveData8GetFrameEv
+0x78C2B936 paf::PhSaveData::GetFrame() const
 0xF0947035 ctanhf
 0x49609306 cellGemSetRumble
-0x059D01A6 _ZN3paf5PhWeb33SetChangeNavigationStatusCallbackEPFvPS0_NS0_20CEPhNavigationStatusEE
+0x059D01A6 paf::PhWeb::SetChangeNavigationStatusCallback(void (*)(paf::PhWeb*, paf::PhWeb::CEPhNavigationStatus))
 0xC097E7DD sceNpUtilSerializeJid
 0x642E3D18 _frexpf4
 0x4D5FF8E2 cellFsRead
@@ -4136,7 +4136,7 @@
 0x6137D196 memalign
 0xEF4D8AD7 cellVdecOpenExt
 0x1D14D6E4 sys_net_get_lib_name_server
-0xBBFF3B2F _ZN3paf7PhClock7GetTimeERNS0_10datetime_tE
+0xBBFF3B2F paf::PhClock::GetTime(paf::PhClock::datetime_t&)
 0xD888F42A _QN4cell5Daisy4Lock8pushOpenEv
 0xACE6D203 sceNpSignalingClearCtxVsh
 0x168FCECE sceNpManagerGetAccountAge
@@ -4155,7 +4155,7 @@
 0xB66D1C46 sceNpManagerGetEntitlementIdList
 0x3E5EED36 sys_dbg_get_spu_thread_name
 0x9549D22C sceNpTusGetMultiUserVariableVUserAsync
-0x08C7D637 _ZN17xCBResultIterator8GetTotalEPi
+0x08C7D637 xCBResultIterator::GetTotal(int*)
 0x6D996018 cellSysutilPrintShutdown
 0xACD37D51 sceSystemFileOverWriteToMem
 0x17E56280 bXCeMemAlloc
@@ -4166,34 +4166,34 @@
 0x953F1E14 sceNetCtlAddHandlerVsh
 0xE73CB0D2 cellSearchPrepareFile
 0x253B7210 _rand_real2_TT800
-0x7FC8F72C _ZN16sysutil_cxmlutil12PacketWriter5WriteEPKvjPv
+0x7FC8F72C sysutil_cxmlutil::PacketWriter::Write(void const*, unsigned int, void*)
 0xAC6693D8 cellImeJpModeCaretRight
 0xC8365EE7 cellCryptoPuEccMod
 0x793BBF51 cellNetCtlDelHandlerGameInt
 0x5A763D0E cellSysutilAvcExtSetShowNamePlate
-0x563FD2BE _ZNSt6localeC2ERKS_PKci
+0x563FD2BE std::locale::locale(std::locale const&, char const*, int)
 0x69452CBA cellVideoPlayerGetVolume
 0x1650AEA4 cellSslEnd
 0xC77D9AE2 cellGcmSetLineStipplePattern
 0x2AE79BE8 cellJpgEncWaitForInput
 0x74444EF2 divx311DecFlushPicture
 0xD42657DD cellSysutilAvc2StartStreaming2
-0x30195CF5 _ZNKSt8numpunctIcE11do_groupingEv
+0x30195CF5 std::numpunct<char>::do_grouping() const
 0x4569518C malloc_stats
 0x4C75DEB8 cellSpursUnsetExceptionEventHandler
 0xE58FC9B5 erfl
 0x3E22CB4B cellMsgDialogOpenErrorCode
 0x2A4C99A6 sceNpCommerceDestroyCtxVsh
 0xDB70756A cellDivXDrmAllowDecrypt
-0x688EACFF _ZN3paf10PhItemSpin8GetStyleEiRb
+0x688EACFF paf::PhItemSpin::GetStyle(int, bool&)
 0x1AE28192 cellAtracMultiAddStreamData
 0xFC58CA65 InputDevice_EnableAnalog
-0xC610617F _Z23x3USBMass_GetMountEntryyP19_xUSBMassMountEntry
+0xC610617F x3USBMass_GetMountEntry(unsigned long long, _xUSBMassMountEntry*)
 0xA7FD2F5B cellCameraSetNotifyEventQueue2
 0x2183EA78 epsonPrintSearchPrinter
 0x9AF30EAF casin
 0x4210C462 sceNpManagerGetSigninId
-0x3BDF774D _ZN12bXCeAttrList5ClearEv
+0x3BDF774D bXCeAttrList::Clear()
 0xE93ABFCA ctan
 0x80A28D48 cellAvchatJpgDecOpen
 0xD719F8EE ft_lzwstate_io
@@ -4204,7 +4204,7 @@
 0xD6A8C7F9 cellAvcEncCancelStream
 0x9C9D7B0D strtold
 0x55D4866E fgetws
-0x79A562D5 _ZN3vsh31SetButtonNavigationString_EnterEPKw
+0x79A562D5 vsh::SetButtonNavigationString_Enter(wchar_t const*)
 0xDFB52083 _Stoxflt
 0x70CB170C cellKbConfigSetArrangement
 0xD125B89E conjf
@@ -4212,39 +4212,39 @@
 0x871AF804 cellSync2CondSignal
 0x4D99E6DF cellAvchatJpgDecSetEventInfo
 0x75FCA288 cellSailPlayerGetCurrentDescriptor
-0xD4946610 _ZN3paf8DateTime3NowEv
-0x67437488 _ZN3paf8PhWidget14SetRot_ontimerERK4vec4PS0_i
+0xD4946610 paf::DateTime::Now()
+0x67437488 paf::PhWidget::SetRot_ontimer(vec4 const&, paf::PhWidget*, int)
 0x9D9CB96B sceNpCommerce2DestroyGetCategoryContentsResult
 0xCA5AC370 cellAudioQuit
 0x842E7E06 cellFsChown
 0x0D5B4A14 cellFsReadWithOffset
-0x6F0B1117 _ZN10bXCeXMLToD10InitializeEv
+0x6F0B1117 bXCeXMLToD::Initialize()
 0xAC893127 fgetc
 0xDFD63B62 sceNpLookupUserProfile
 0xB202F0E8 cellMusicExportFromFile
 0x434419C8 cellHttpClientSetCookieStatus
 0x28BC1409 cellAudioUnsetPersonalDevice
-0xF2B730FB _ZN3paf12MiconPointee6AddRefEv
+0xF2B730FB paf::MiconPointee::AddRef()
 0xE2EABB32 eucjp2kuten
 0xF5E23DA4 ftc_node_destroy
-0x161C3786 _ZN3vsh3fim19friendDeleteRequestEPvPFiiS1_ES1_
+0x161C3786 vsh::fim::friendDeleteRequest(void*, int (*)(int, void*), void*)
 0x2DE0D663 cellSaveDataListSave2
 0xD657D01F CEComAttachThread
 0x8DA844E1 sceNetApCtlGetInfoVsh
 0xC5B5B2F3 BIO_ptr_ctrl
-0xAC6C23C0 _ZNKSt7num_getIcSt19istreambuf_iteratorIcSt11char_traitsIcEEE6do_getES3_S3_RSt8ios_baseRNSt5_IosbIiE8_IostateERy
+0xAC6C23C0 std::num_get<char, std::istreambuf_iterator<char, std::char_traits<char>>>::do_get(std::istreambuf_iterator<char, std::char_traits<char>>, std::istreambuf_iterator<char, std::char_traits<char>>, std::ios_base&, std::_Iosb<int>::_Iostate&, unsigned long long&) const
 0x6B8F5CB9 cellMediatorSign
 0x5B45439D cellRecStop
 0x9439E4CD wcsncat
 0x8F87A06B sceNpTusInit
 0xF5CD1E19 cosf4
-0xD6808BD8 _ZN3paf5PhWeb10WidgetTypeEv
-0x2293AB67 _ZN3paf7PhClockC1EPNS_8PhWidgetE
+0xD6808BD8 paf::PhWeb::WidgetType()
+0x2293AB67 paf::PhClock::PhClock(paf::PhWidget*)
 0x433F6EC0 cellKbInit
 0x566893CE inet_lnaof
 0xA9F703E3 cellJpgDecExtOpen
 0x437151F0 _QN4cell5Daisy16LFQueue2PushOpenEPNS0_8LFQueue2E
-0xDC65AB00 _ZNSt9money_putIcSt19ostreambuf_iteratorIcSt11char_traitsIcEEED1Ev
+0xDC65AB00 std::money_put<char, std::ostreambuf_iterator<char, std::char_traits<char>>>::~money_put()
 0xF8292A94 cellM4vEncQueryPresetParameter
 0xF9073A24 cellMusicGetVolume2
 0xA0D447EB smvd2GetPicture
@@ -4252,20 +4252,20 @@
 0xDB9819F3 cellGameDataCheck
 0xF08BA0D0 cellNetCtlDisconnectGameInt
 0x8D74012D cellAvsetSetAudioControlInfo
-0x86C66A99 _ZN3vsh3fim18setMePresenceStateEi
+0x86C66A99 vsh::fim::setMePresenceState(int)
 0xBBB244B7 sceNpTusTryAndSetVariableAsync
 0x2CAEA755 _Once
 0xDC57C0AC naacEncGetLibraryVersion
 0xC20DC634 sceNpCommerceBrowseShopStartVsh
 0x9164EFD1 FT_Set_Var_Blend_Coordinates
-0x458D68AE _ZN7bXUtils11GetDocumentEPcPP7bXCeDoc
+0x458D68AE bXUtils::GetDocument(char*, bXCeDoc**)
 0x27CB8BC2 cellSaveDataListDelete
 0xB2D054DF cellMusicDecodeRead2
 0x476B5591 fmaf
 0xA36335A5 cellSysutilDisableBgmPlaybackEx
-0x350B4536 _ZN3paf9Job_StartEPNS_9Job_QueueEPFiPvPNS_10Job_ThreadEES2_iiPFviS2_S4_iE
+0x350B4536 paf::Job_Start(paf::Job_Queue*, int (*)(void*, paf::Job_Thread*), void*, int, int, void (*)(int, void*, paf::Job_Thread*, int))
 0x7DA5AB2D cellFsUtilGetFsInfo
-0xDAB0A910 _ZNSt15basic_streambufIwSt11char_traitsIwEE9pbackfailEi
+0xDAB0A910 std::basic_streambuf<wchar_t, std::char_traits<wchar_t>>::pbackfail(int)
 0x91CDFDB0 asinf4fast
 0xC2E45C8B cellMarlinDRMFin
 0x40FFD58F ATEopen
@@ -4275,14 +4275,14 @@
 0x94F5ADA6 cellGcmSetFragmentProgramLoadLocation
 0x44B1BC61 cellGifDecDecodeData
 0x4B573039 FT_Get_Glyph
-0xF467C45F _ZN3paf8PhWidget8SetStyleEiRK4vec4
+0xF467C45F paf::PhWidget::SetStyle(int, vec4 const&)
 0x827CB70E cellApostSrcFinalizeHandle
 0x2BC9DEE6 raw_spu_read_short
 0xB9DA87D3 sys_dbg_get_coredump_params
 0x10EF39F6 cellVpostClose
-0x71254CDA _ZN8XMWIOCTL13DeviceControlEjPvyS0_y
-0x54124AA2 _Z18xcbSetMusicBitratePvi
-0xF490B679 _ZN3vsh11ContentInfo4InfoEff
+0x71254CDA XMWIOCTL::DeviceControl(unsigned int, void*, unsigned long long, void*, unsigned long long)
+0x54124AA2 xcbSetMusicBitrate(void*, int)
+0xF490B679 vsh::ContentInfo::Info(float, float)
 0xA7EDE268 cellGcmReserveIoMapSize
 0x68C25868 FT_Add_Default_Modules
 0x494613C7 cellSpursJobChainGetSpursAddress
@@ -4290,12 +4290,12 @@
 0xA6A31A38 sceNpClansCreateClan
 0x3DE928EE cellGcmCgGetUCode
 0x7F9976C7 ft_stub_set_char_sizes
-0x05471587 _ZNK7bXCeDoc11GetNodeTypeEP8bXCeNode
+0x05471587 bXCeDoc::GetNodeType(bXCeNode*) const
 0x94989003 sceNpTusAddAndGetVariable
-0xC79278EC _ZNSt15basic_streambufIcSt11char_traitsIcEE5imbueERKSt6locale
+0xC79278EC std::basic_streambuf<char, std::char_traits<char>>::imbue(std::locale const&)
 0x05152522 cellMarlinDRMDeleteLicense
 0x6CBD0B0F CEUQueue_delete
-0x54D13728 _ZN3vsh17ViewActivate_GameEv
+0x54D13728 vsh::ViewActivate_Game()
 0x2FC0AB58 cellSysutilAvc2SetVideoMuting
 0xD4B256E0 epsonPrintCancelJob
 0x50B86D94 sceNpSignalingAddExtendedHandler
@@ -4309,13 +4309,13 @@
 0x7AB47F7E cellFontEnd
 0xAA6269A8 cellSpursInitializeWithAttribute
 0x92F476F1 sceUpdateDownloadReadData
-0x3329CAAA _ZNK4cxml9Attribute8GetFloatEPf
+0x3329CAAA cxml::Attribute::GetFloat(float*) const
 0x890F9E5A cellSpursEventFlagGetDirection
 0x3DBC3BEE opendir
-0xABDC2B49 _ZNSt9money_getIwSt19istreambuf_iteratorIwSt11char_traitsIwEEE7_GetcatEPPKNSt6locale5facetE
+0xABDC2B49 std::money_get<wchar_t, std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>>::_Getcat(std::locale::facet const**)
 0xD7653782 sinhf
-0x2C5AD7B4 _Z36_sce_np_sysutil_recv_packet_fixedmemiPN16sysutil_cxmlutil11FixedMemoryERN4cxml8DocumentERNS2_7ElementE
-0x39D01FCA _ZN3vsh20FormatFileSizeStringEPwij
+0x2C5AD7B4 _sce_np_sysutil_recv_packet_fixedmem(int, sysutil_cxmlutil::FixedMemory*, cxml::Document&, cxml::Element&)
+0x39D01FCA vsh::FormatFileSizeString(wchar_t*, int, unsigned int)
 0x247414D0 cellSpursQueueClear
 0x1EA02E2F cellFsArcadeHddSerialNumber
 0xB3338072 sceNpMatchingShareCtx
@@ -4329,32 +4329,32 @@
 0x54C2844E spu_raw_snprintf
 0x439FBA17 cellPamfReaderGetEpIteratorWithTimeStamp
 0x62BF1D6C swprintf
-0x5ADF9060 _ZNKSt5ctypeIcE8do_widenEPKcS2_Pc
+0x5ADF9060 std::ctype<char>::do_widen(char const*, char const*, char*) const
 0x07274304 csinh
-0x2DB4683D _ZN3paf6PhText13SetCurrentPosEj
-0x46E3E3FD _ZNK3paf11PhLabelText13GetLineHeightEv
+0x2DB4683D paf::PhText::SetCurrentPos(unsigned int)
+0x46E3E3FD paf::PhLabelText::GetLineHeight() const
 0xF7ACD655 _sys_net_lib_bnet_control
-0x1524811A _ZN3paf5PhWeb25SetPaintFocusRectCallbackEPFvPS0_ffffE
+0x1524811A paf::PhWeb::SetPaintFocusRectCallback(void (*)(paf::PhWeb*, float, float, float, float))
 0x511D386B EUCJPstoSJISs
 0x0E2939E5 cellFsFtruncate
-0x915890C7 _ZN3paf8PhXmList10UpdateFormEf
-0x39D3A244 _ZN3paf8PhXmItem12AnimIconStopEv
+0x915890C7 paf::PhXmList::UpdateForm(float)
+0x39D3A244 paf::PhXmItem::AnimIconStop()
 0x6DFF610C cellAvsetSetVideoMode
 0x42A32983 cellPhotoRegistFromFile
 0xEDABE7DB at3enc_init
 0x0E9DFE48 sceNpSignalingDeactivateConnectionVsh
 0xA8AFA7D4 sceNpBasicGetCustomInvitationEntryCount
 0xEC73B49D sceNetCtlGetStateVsh
-0xF78B2215 _ZN3vsh16RebootSafeMemory5ClearEv
+0xF78B2215 vsh::RebootSafeMemory::Clear()
 0x347C1EE1 atanf4
 0xAEE8277C ft_service_list_lookup
 0x3F3BD413 sceNpMatching2SendLobbyChatMessage
 0xE6F4B68C smvd4DecodePicture
 0x2EDCFF92 cellSpursTasksetSetExceptionEventHandler
-0xC7CF2A06 _ZN3paf6PhText12SetFirstLineEf
+0xC7CF2A06 paf::PhText::SetFirstLine(float)
 0xDCDF003A cellHttpAuthCacheFlush
 0x5FAFE92B cellCryptoPuSha1Hash
-0xB71DC906 _ZNK3paf11PhLabelText12GetLineCountEv
+0xB71DC906 paf::PhLabelText::GetLineCount() const
 0x452B09FB cellAsfParser2AStdSeekPacketNumber
 0x96022EEF SSLCERT_NAME_cmp
 0xBCCD70DD cellSysutilAvcCancelJoinRequest
@@ -4362,26 +4362,26 @@
 0x8463730C dlnaPrintEndJob
 0x7498887B _sys_strchr
 0xEA6DC1AD cellFiberPpuUtilWorkerControlCheckFlags
-0xDF7EDB4D _ZSt9use_facetISt10moneypunctIwLb1EEERKT_RKSt6locale
+0xDF7EDB4D std::moneypunct<wchar_t, true> const& std::use_facet<std::moneypunct<wchar_t, true>>(std::locale const&)
 0xBF9CD933 cellFiberPpuSchedulerTraceInitialize
-0x6FE060A0 _ZNSt15basic_streambufIwSt11char_traitsIwEE7seekposESt4fposISt9_MbstatetENSt5_IosbIiE9_OpenmodeE
-0x8B532D16 _Z9PSJS_ExecRK11PSJSContext
-0x14E3FAA5 _ZNKSt5ctypeIwE9do_narrowEwc
+0x6FE060A0 std::basic_streambuf<wchar_t, std::char_traits<wchar_t>>::seekpos(std::fpos<std::_Mbstatet>, std::_Iosb<int>::_Openmode)
+0x8B532D16 PSJS_Exec(PSJSContext const&)
+0x14E3FAA5 std::ctype<wchar_t>::do_narrow(wchar_t, char) const
 0x844A07C3 cellDivXDrmInit
 0xEE0DB701 _Csubcr
 0x37907F9F cellFsWidgetStat
-0x63F9074F _ZN3paf10HeapMemory19check_memory_boundsEv
+0x63F9074F paf::HeapMemory::check_memory_bounds()
 0xD3790A86 cellOskDialogSetDeviceMask
 0x6FCDF6E3 cellSpursGetSpuGuid
 0xF677A137 sceNpMatching2GetRoomMemberDataExternalListVsh
 0x4ABE830E cellUsbPspcmWaitBindAsync
 0x12A55FB7 mbrtowc
 0xA7F04A24 sceSdSetIndex
-0x2D9D1687 _ZN3paf8PhXmList10InsertItemEif
+0x2D9D1687 paf::PhXmList::InsertItem(int, float)
 0xEB9C1E5E cellHttpClientGetCookieStatus
 0xD6D57583 ATEgetRegWordNext
 0x4875601D _exp2f4fast
-0x91404635 _ZN3paf4View9SetLocaleE6Locale
+0x91404635 paf::View::SetLocale(Locale)
 0x365B24CE SSLCERT_get_notAfter
 0xA3000F72 sceUpdateDownloadCreateCtx
 0x5923488B FT_List_Insert
@@ -4402,7 +4402,7 @@
 0xD8CCC3D5 cellGcmSetFrontPolygonMode
 0xDB19194C sceNpCommerce2GetGameSkuInfoFromGameProductInfo
 0x3B95270D smvd2GetMemorySize
-0x5656CCFF _ZNKSt7collateIcE10do_compareEPKcS2_S2_S2_
+0x5656CCFF std::collate<char>::do_compare(char const*, char const*, char const*, char const*) const
 0xBDC43FA9 at3enc_open
 0x11F071CB cellSysutilAvc2StopStreaming2
 0xF8509925 cellRtcTickAddMicroseconds
@@ -4413,16 +4413,16 @@
 0x1A2518A2 cellGemEnableMagnetometer
 0x53F529FE cellFontGlyphSetupVertexesGlyph
 0x3F0808AA sceNpBasicSetPresence
-0xC4F74046 _ZN3paf5Image8ToBufferEb
+0xC4F74046 paf::Image::ToBuffer(bool)
 0xD1462438 cellSailSoundAdapterFinalize
 0xF7F7FB20 _sys_free
-0x07B6C924 _ZTv0_n12_NSt13basic_ostreamIwSt11char_traitsIwEED1Ev
+0x07B6C924 virtual thunk to std::basic_ostream<wchar_t, std::char_traits<wchar_t>>::~basic_ostream()
 0xFCF08193 expf
 0x1C25470D sceNpTrophyCreateHandle
 0xE0E1AE12 cellVoiceEnd
-0x9C4C1564 _ZN3paf7PhEventC1Ejjjiiii
+0x9C4C1564 paf::PhEvent::PhEvent(unsigned int, unsigned int, unsigned int, int, int, int, int)
 0x9245E01B _divf4
-0x97E124F1 _ZN3paf10PhItemSpinD2Ev
+0x97E124F1 paf::PhItemSpin::~PhItemSpin()
 0x3A210C93 swscanf
 0xA9A76FB8 UCS2toUTF8
 0x50EC3696 FT_Get_PFR_Metrics
@@ -4430,13 +4430,13 @@
 0xCFDD8E87 cellSysutilDisableBgmPlayback
 0x80A88A5C sceNetHttpXmlGetResourceLocation
 0x0F1F13D3 cellNetCtlNetStartDialogUnloadAsync
-0x18932F5F _Z14xcbGetFileSizePvPy
+0x18932F5F xcbGetFileSize(void*, unsigned long long*)
 0x30F0B5AB cellVoiceWriteToIPortEx
-0xCB7D00A4 _ZNSt6_WinitD2Ev
-0x680EDACC _ZN20MmsMdImporterContextC1EP20MmsMdImporterManagerPK17_xMutex_InterfacePvP44_MmsMdImporterGetMetadataCallbackInformation
+0xCB7D00A4 std::_Winit::~_Winit()
+0x680EDACC MmsMdImporterContext::MmsMdImporterContext(MmsMdImporterManager*, _xMutex_Interface const*, void*, _MmsMdImporterGetMetadataCallbackInformation*)
 0x1F1778A0 mios2_Client_Initialize
 0x99A72146 vsnprintf
-0x2675C91A _ZN4xMMS10SyncSearchEPvS0_P21xMMSSearchParameter_tPS0_
+0x2675C91A xMMS::SyncSearch(void*, void*, xMMSSearchParameter_t*, void**)
 0x4711CB7F cellGifDecExtCreate
 0xEB4027D6 sceNpSignalingActivateConnectionVsh
 0xCAC7E7D7 cellMicSysShareStart
@@ -4453,10 +4453,10 @@
 0xDFD41734 _Exp
 0x21316B3F cellDivXDrmGetRegistrationCode
 0x44673F07 cellCameraRemoveNotifyEventQueue2
-0x65F530A4 _ZN3paf8PhWidget10SetColor32Ej
+0x65F530A4 paf::PhWidget::SetColor32(unsigned int)
 0xFACB3CED cellSpursJobQueuePort2Sync
-0xFB36C588 _ZNSt9strstreamC1EPciNSt5_IosbIiE9_OpenmodeE
-0x2D50650F _ZSt9use_facetISt10moneypunctIcLb1EEERKT_RKSt6locale
+0xFB36C588 std::strstream::strstream(char*, int, std::_Iosb<int>::_Openmode)
+0x2D50650F std::moneypunct<char, true> const& std::use_facet<std::moneypunct<char, true>>(std::locale const&)
 0x2E1C5068 sceNpMatchingDestroyCtx
 0xB9B430C2 FT_Set_Charmap
 0xACB9EE8E sceNpBasicUnregisterHandler
@@ -4466,12 +4466,12 @@
 0x3602BC80 sceNpTusTryAndSetVariableVUser
 0x0B0D272F _malloc_finalize
 0x990D6A8D cellAvsetAudioCPControl
-0x2B35D7DD _ZNK3paf11PhLabelText14GetMaxAscenderEv
+0x2B35D7DD paf::PhLabelText::GetMaxAscender() const
 0xDF1C334E cellGcmSwapVout
 0x4D19C631 cellFontSetupRenderScalePoint
 0x87630976 cellSpursEventFlagAttachLv2EventQueue
 0x619B1427 cellWebBrowserConfigSetTabCount2
-0x986427A7 _ZN3paf9PhHandler11SetCallBackEiPFvPNS_8PhWidgetEPNS_7PhEventEPvES5_
+0x986427A7 paf::PhHandler::SetCallBack(int, void (*)(paf::PhWidget*, paf::PhEvent*, void*), void*)
 0x0CBEDF6A cellCameraClosePost
 0xBD1BF0B7 pafGuDataLocation
 0x17C031D7 spu_thread_read_ulong
@@ -4483,27 +4483,27 @@
 0x9FB97B10 cellWebBrowserNavigate2
 0x48154C9B cellSyncQueuePeek
 0x02DC41EE cellSysutilAvc2JoinChat
-0x2F58C5DF _ZN3paf4View14PageInactivateEPKc
+0x2F58C5DF paf::View::PageInactivate(char const*)
 0xADD2E49F Struct_FTRenderBuf
 0x9AE33D35 sceAdGetConnectionMetadata
 0x10C8D8FE cellCryptoPuFips186Prng
 0x65935877 ilogbf
 0xB53B3D42 cellWebBrowserCreateWithConfigFull
 0x620E35A7 sys_game_get_system_sw_version
-0x7DA7FDB1 _ZNKSt7num_putIwSt19ostreambuf_iteratorIwSt11char_traitsIwEEE6do_putES3_RSt8ios_basewy
+0x7DA7FDB1 std::num_put<wchar_t, std::ostreambuf_iterator<wchar_t, std::char_traits<wchar_t>>>::do_put(std::ostreambuf_iterator<wchar_t, std::char_traits<wchar_t>>, std::ios_base&, wchar_t, unsigned long long) const
 0xF7DDB471 _Setgloballocale
 0x20BA8E1A PAF_Resource_DOMGetNodeChildByPos
 0x039D70B7 cellSpursQueueDetachLv2EventQueue
-0x96486AF8 _ZN3paf11PhLabelText15SetColumnOffsetEf
+0x96486AF8 paf::PhLabelText::SetColumnOffset(float)
 0x3C775CEA cellSailFeederAudioNotifyFrameOut
 0x1E411261 cellImeJpMoveFocusClause
 0x88F79869 cellHttpClientSetCacheStatus
 0xD12E40AE sceNpLookupNpIdAsync
-0x429ED666 _ZN3paf11PhLabelText12SetLineColorEjRK4vec4
+0x429ED666 paf::PhLabelText::SetLineColor(unsigned int, vec4 const&)
 0x7F881BE1 cellWebBrowserCreate
 0xBE0E3EE2 sceNpDrmVerifyUpgradeLicense2
-0x708CF940 _ZNKSt8time_getIwSt19istreambuf_iteratorIwSt11char_traitsIwEEE11do_get_dateES3_S3_RSt8ios_baseRNSt5_IosbIiE8_IostateEPSt2tm
-0x2E730921 _ZN3vsh3fim12getMeCommentEv
+0x708CF940 std::time_get<wchar_t, std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>>::do_get_date(std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>, std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>, std::ios_base&, std::_Iosb<int>::_Iostate&, std::tm*) const
+0x2E730921 vsh::fim::getMeComment()
 0xC9645C41 cellGameDataCheckCreate2
 0x8BC98CB9 Heap_Destroy
 0x98F74C9A sceNpMatching2SignalingGetLocalNetInfo
@@ -4511,23 +4511,23 @@
 0x7A9421D8 sceNpGetStatusDuration
 0xA1DBB466 _Gettime
 0x482ADDB7 cellAvcEncOpen
-0x79EFF338 _ZNK4cxml4File7GetAddrEv
-0x9F528CD3 _ZNKSt7codecvtIccSt9_MbstatetE6do_outERS0_PKcS4_RS4_PcS6_RS6_
-0xD93D52B1 _ZNSt9money_putIwSt19ostreambuf_iteratorIwSt11char_traitsIwEEED1Ev
+0x79EFF338 cxml::File::GetAddr() const
+0x9F528CD3 std::codecvt<char, char, std::_Mbstatet>::do_out(std::_Mbstatet&, char const*, char const*, char const*&, char*, char*, char*&) const
+0xD93D52B1 std::money_put<wchar_t, std::ostreambuf_iterator<wchar_t, std::char_traits<wchar_t>>>::~money_put()
 0xB400F226 isupper_ascii
 0x44F6D0D2 cellGcmCgSetRegisterCount
-0xE206C08F _ZNSt13basic_filebufIwSt11char_traitsIwEED0Ev
+0xE206C08F std::basic_filebuf<wchar_t, std::char_traits<wchar_t>>::~basic_filebuf()
 0x543A7C29 cellGcmSetBlendOptimization
 0x0A2069C7 cellRescGetNumColorBuffers
 0x26563DDC cellSailPlayerNext
 0x398A3DEE MSJIStoUTF8
-0xA4D0FDCB _ZN3paf9PhHandler18HandleKeycodeEventEPNS_7PhEventE
+0xA4D0FDCB paf::PhHandler::HandleKeycodeEvent(paf::PhEvent*)
 0xF5507729 cellSpursEventFlagSet
 0xDC578057 sys_mmapper_map_memory
 0x0D0C2F0C cellSailDescriptorSetEs
 0x8FF02267 cellImeJpAllowExtensionCharacters
 0x60D34743 cellAvsetSetVideoFormat
-0x76DB6974 _ZNSt7codecvtIwcSt9_MbstatetED0Ev
+0x76DB6974 std::codecvt<wchar_t, char, std::_Mbstatet>::~codecvt()
 0x8421B9C7 SSL_new
 0xAC9E2BC9 scePS2OSD_TitleWordWrapSJIS
 0xFD0EB5AE sceNpSignalingDeactivateConnection
@@ -4537,7 +4537,7 @@
 0x66515C18 cellMinisSaveDataFixedLoad
 0x4FEC43A9 cellSailRecorderSetFeederVideo
 0x7F21C918 cellOskDialogAddSupportLanguage
-0x547917DF _ZN3paf8PhWidget8GetStyleEiRi
+0x547917DF paf::PhWidget::GetStyle(int, int&)
 0x27AC51E4 cellStorageDataImportMove
 0xB792CA1A cellSpursLFQueueGetTasksetAddress
 0xC78AC9D0 scalbn
@@ -4551,13 +4551,13 @@
 0xDF6A5E21 cellAvcEncSmallGetStream
 0x84F84BD5 dlnaPrintInitDriver
 0x758F33DC nearbyint
-0xBF66BF2D _ZN3paf10PhCheckBox10WidgetTypeEv
+0xBF66BF2D paf::PhCheckBox::WidgetType()
 0x48C5020D cellCelp8EncGetAu
 0x6403D96E smf_ApPl_GetSampleInfo_M
 0x40AD67EB cellMediatorCreateContext
 0x64DBB89D sceNpSignalingCancelPeerNetInfo
 0x4F5D8D20 cellHttpResponseGetHeader
-0x7257947C _ZNK7bXCeDoc11GetAttrNameEP8bXCeNode
+0x7257947C bXCeDoc::GetAttrName(bXCeNode*) const
 0x30555A9C cellDecPsnvideoEvaluateLicense
 0x97CF128E cellUsbdControlTransfer
 0xBBAA300B f_log1pf
@@ -4570,27 +4570,27 @@
 0xE84BBCAF sceNpCommerceGetProductCategoryFinishVsh
 0x0C14CFCC fesetenv
 0x8B14BE9C FTC_CMapCache_Lookup
-0x9FB0F27B _ZN3paf10PhProgress8SetValueEf
+0x9FB0F27B paf::PhProgress::SetValue(float)
 0xD97C7372 FTRenderSurface_SetSissorRect
 0x26EF50ED asinh
 0xF106AAD3 svc1dGetMemorySize
 0x9E0FAFD3 cellSysutilAvcExtStartMicDetection
-0x20957CD4 _ZN16sysutil_cxmlutil12PacketWriterC1EiiRN4cxml8DocumentE
+0x20957CD4 sysutil_cxmlutil::PacketWriter::PacketWriter(int, int, cxml::Document&)
 0x08139BD2 _fmaxf4
-0x273BE056 _ZNKSt9money_putIcSt19ostreambuf_iteratorIcSt11char_traitsIcEEE8_PutmfldES3_bRSt8ios_basecbSs
+0x273BE056 std::money_put<char, std::ostreambuf_iterator<char, std::char_traits<char>>>::_Putmfld(std::ostreambuf_iterator<char, std::char_traits<char>>, bool, std::ios_base&, char, bool, std::basic_string<char, std::char_traits<char>, std::allocator<char>>) const
 0x3F125E2E spu_thread_write_short
 0x45034943 nan
 0x15F0C5F2 cellGcmSetPerfMonPopMarker
 0x691BFEBD sceNpMatching2SendLobbyChatMessageVsh
-0xC44F501D _ZN4vec4aSEf
+0xC44F501D vec4::operator= (float)
 0x06E681ED cellFsAccess
-0x87B1F5EB _ZNSt9exceptionD0Ev
+0x87B1F5EB std::exception::~exception()
 0xD78B41CB FT_Stroker_LineTo
 0x9E460733 naacEncCreateInstance
-0x9924F11A _ZN3paf7PhModel12SetFrameRateEf
+0x9924F11A paf::PhModel::SetFrameRate(float)
 0x90F2798C BIO_new_mem
 0x25BEEE5A __raw_spu_printf
-0x8AD11D24 _ZN4cxml8Document18GetDocumentElementEv
+0x8AD11D24 cxml::Document::GetDocumentElement()
 0x3124A0E0 cellM4vEncReopen
 0xC24E39FC FT_List_Add
 0x44D2BA34 cellAudioOutGetConfiguration2
@@ -4599,13 +4599,13 @@
 0x6AF85CDF cellSync2QueueFinalize
 0xCA0A2D04 sceNpSignalingGetConnectionStatus
 0x58320830 _WLitob
-0x3A50E116 _ZN3paf8PhXmItem8BlinkEndEf
+0x3A50E116 paf::PhXmItem::BlinkEnd(float)
 0xEDADD797 cellSaveDataDelete2
 0xA2D4189B cellDmuxQueryAttr
 0x2D9A1997 cellSysutilAvcExtGetWindowShowStatus
 0xE7B0E69A cellSpursJobSetMaxGrab
-0xCA9160F6 _ZNK3paf9PhNumSpin13GetWidgetTypeEv
-0xF6C178E6 _ZN3paf15SaveDataPointee6AddRefEv
+0xCA9160F6 paf::PhNumSpin::GetWidgetType() const
+0xF6C178E6 paf::SaveDataPointee::AddRef()
 0x942DBDC4 sceNpClansSendMembershipResponse
 0x4D9C615D sceNpBasicGetClanMessageEntry
 0xECF56150 cellSailPlayerSetRendererVideo
@@ -4617,7 +4617,7 @@
 0xE9137453 fwprintf
 0x7670FF88 __cxa_pure_virtual
 0xB37982EA _Getstr
-0x30CE43D4 _ZNSt8numpunctIcED0Ev
+0x30CE43D4 std::numpunct<char>::~numpunct()
 0x4A6CA9A6 powf4
 0x18E48B5D wscanf
 0x4A1964A6 smvd2GetSideInfoPic
@@ -4625,10 +4625,10 @@
 0x17752BAB wcsftime
 0x7919F414 _f_nearbyintf
 0x6F3986A6 cellGcmConvertSwizzleFormat
-0xD7F0A558 _ZN3paf13PhAppearPlane11RenderStateEjb
-0x6E61426D _ZNSt13basic_filebufIwSt11char_traitsIwEED1Ev
+0xD7F0A558 paf::PhAppearPlane::RenderState(unsigned int, bool)
+0x6E61426D std::basic_filebuf<wchar_t, std::char_traits<wchar_t>>::~basic_filebuf()
 0x7A0A83C4 cellFontInitLibraryFreeTypeWithRevision
-0xC84F0B21 _ZN3paf10MessageBox12SetLayoutPosEii
+0xC84F0B21 paf::MessageBox::SetLayoutPos(int, int)
 0x16F1CE55 _sce_net_set_ip_and_mask
 0x27E7BD51 cellPngEncCoreWriteHeader
 0xDE1BB092 init_by_array_TT800
@@ -4637,30 +4637,30 @@
 0x6B4E0DE6 cellSaveDataListImport
 0x744C1544 cellSysCacheClear
 0x5C832BD7 cellUsbdSetThreadPriority2
-0x585EC026 _ZN4vec4ixEi
+0x585EC026 vec4::operator[] (int)
 0xE12C8C19 cellRemotePlayGetComparativeVolume
-0x1E54DB1E _ZN3paf8PhWidget8GetStyleEiRb
+0x1E54DB1E paf::PhWidget::GetStyle(int, bool&)
 0xE8586EC6 cellPamfReaderGetEpIteratorWithIndex
 0xDF1FF79F sceNpC7yScoreCreateTransactionVsh
 0x4B55F456 sys_dbg_get_ppu_thread_name
-0x8BFD4395 _ZNSt9basic_iosIwSt11char_traitsIwEE4initEPSt15basic_streambufIwS1_Eb
+0x8BFD4395 std::basic_ios<wchar_t, std::char_traits<wchar_t>>::init(std::basic_streambuf<wchar_t, std::char_traits<wchar_t>>*, bool)
 0xFC0428A6 strdup
 0xFD86FFC1 sceSdRemoveValue
 0xC8F4E2CF pafGuTexFilter
-0x78A142D0 _ZSt7_FiopenPKcNSt5_IosbIiE9_OpenmodeEi
+0x78A142D0 std::_Fiopen(char const*, std::_Iosb<int>::_Openmode, int)
 0xE921EAA5 pafGuCgSetShader
 0x474609E2 cellVoiceGetMuteFlag
 0x542B74CC sceNpCommerce2EmptyStoreCheckStart
 0x726FC1D0 cellPngDecExtDecodeData
-0x3F9CB259 _ZNKSt7num_getIwSt19istreambuf_iteratorIwSt11char_traitsIwEEE6do_getES3_S3_RSt8ios_baseRNSt5_IosbIiE8_IostateERl
+0x3F9CB259 std::num_get<wchar_t, std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>>::do_get(std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>, std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>, std::ios_base&, std::_Iosb<int>::_Iostate&, long&) const
 0x8107277C cellRescSetBufferAddress
 0xC7FB73D6 f_lrintf
 0x5CF9C3F0 FTManager_SetFontOpenMode
 0xB7BA4AEB _WStoul
 0x701F6FC6 smf_ApPs_GetAVCDecoderConfigInfoExt
-0x9C486668 _ZNSt6locale7_Locimp9_MakexlocERKSt8_LocinfoiPS0_PKS_
+0x9C486668 std::locale::_Locimp::_Makexloc(std::_Locinfo const&, int, std::locale::_Locimp*, std::locale const*)
 0x329A4540 _WPrintf
-0xEBD4B51D _ZNKSt8time_getIwSt19istreambuf_iteratorIwSt11char_traitsIwEEE11do_get_yearES3_S3_RSt8ios_baseRNSt5_IosbIiE8_IostateEPSt2tm
+0xEBD4B51D std::time_get<wchar_t, std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>>::do_get_year(std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>, std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>, std::ios_base&, std::_Iosb<int>::_Iostate&, std::tm*) const
 0x9E4B1DB8 cellAudioAdd2chData
 0xC66BA67E sceNpTusGetMultiUserDataStatusAsync
 0x7CBA9865 _SceAdecCorrectPtsValue_Aac
@@ -4669,30 +4669,30 @@
 0x126656B7 _Btowc
 0xD4770B4D FT_Select_Metrics
 0x8F472054 UTF8stoEUCCNs
-0xB190D6AD _ZN4cell5Daisy22ScatterGatherInterlockC2EPVNS0_16_AtomicInterlockEjPvPFiS5_jE
-0x5FFC22E1 _ZN3paf8PhWidget8GetStyleEiiRb
-0x153DA7D8 _ZN3paf7PhModel8SetFrameEf
+0xB190D6AD cell::Daisy::ScatterGatherInterlock::ScatterGatherInterlock(cell::Daisy::_AtomicInterlock volatile*, unsigned int, void*, int (*)(void*, unsigned int))
+0x5FFC22E1 paf::PhWidget::GetStyle(int, int, bool&)
+0x153DA7D8 paf::PhModel::SetFrame(float)
 0x33CD8C2F cellGcmSysSetTextureContext
 0x1422A425 cellSailProfileSetEsVideoParameter
 0xF2C4A425 cellSysutilAvcByeRequest
 0xE76964F5 sys_game_board_storage_read
-0xB4A8791F _ZNSt8time_putIwSt19ostreambuf_iteratorIwSt11char_traitsIwEEED1Ev
+0xB4A8791F std::time_put<wchar_t, std::ostreambuf_iterator<wchar_t, std::char_traits<wchar_t>>>::~time_put()
 0x2B8B73A9 sceFimPresenceServiceInit
-0x17F4C727 _ZN3paf5PhWeb13SetPointerPosEff
+0x17F4C727 paf::PhWeb::SetPointerPos(float, float)
 0x60EDA245 sceNetUpnpStart
-0x9EF60BF3 _ZNKSt5ctypeIwE10do_tolowerEw
+0x9EF60BF3 std::ctype<wchar_t>::do_tolower(wchar_t) const
 0x02065E3D sceNpMatching2LeaveLobby
-0x4161647F _ZN12bXCeNodeList4ItemEj
+0x4161647F bXCeNodeList::Item(unsigned int)
 0x6C673F78 cellSysutilAvcUnloadAsync
-0x2670B433 _ZNKSt7num_getIwSt19istreambuf_iteratorIwSt11char_traitsIwEEE8_GetffldEPcRS3_S6_RKSt6locale
-0xD951ED2D _ZN3paf5PhWeb16EnableJavaScriptEb
+0x2670B433 std::num_get<wchar_t, std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>>::_Getffld(char*, std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>&, std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>&, std::locale const&) const
+0xD951ED2D paf::PhWeb::EnableJavaScript(bool)
 0x3820170B atxenc_set_config_info
-0xD005CC9F _ZN3paf8PhXmList6RedrawEi
+0xD005CC9F paf::PhXmList::Redraw(int)
 0xE7FA820B cellSaveDataEnableOverlay
 0x01DFD97E Heap_MemAlign
-0x5CA98E4A _ZNSt13basic_filebufIcSt11char_traitsIcEED0Ev
+0x5CA98E4A std::basic_filebuf<char, std::char_traits<char>>::~basic_filebuf()
 0xBED85CB8 cellWebBrowserDestroy
-0x647CB8EF _ZN3paf8PhCamera12UpdateParamsEv
+0x647CB8EF paf::PhCamera::UpdateParams()
 0xA1521D39 divx311DecQueryAttr
 0x6AE10596 sys_config_add_service_listener
 0x82A4561A _put_fd
@@ -4701,38 +4701,38 @@
 0xE2590F60 sceNpClansRemoveAnnouncement
 0x258D003C CEUQueue_clear
 0x1B42101B cellMicIsAttached
-0x9EC88AE6 _ZNKSt5ctypeIwE10do_tolowerEPwPKw
+0x9EC88AE6 std::ctype<wchar_t>::do_tolower(wchar_t*, wchar_t const*) const
 0x6430B2B9 sceNetXmppRetrieveMessages
 0x0F03F712 cellSpursJobQueueAttributeSetSubmitWithEntryLock
 0x330F7005 module_epilogue
 0x81BFEAE8 cellSailFeederVideoFinalize
 0xFBF7E9E4 cellRudpGetMaxSegmentSize
 0x26F023D5 ftell
-0xBD140E12 _ZNKSt8time_getIcSt19istreambuf_iteratorIcSt11char_traitsIcEEE11do_get_timeES3_S3_RSt8ios_baseRNSt5_IosbIiE8_IostateEPSt2tm
+0xBD140E12 std::time_get<char, std::istreambuf_iterator<char, std::char_traits<char>>>::do_get_time(std::istreambuf_iterator<char, std::char_traits<char>>, std::istreambuf_iterator<char, std::char_traits<char>>, std::ios_base&, std::_Iosb<int>::_Iostate&, std::tm*) const
 0xD9C0B463 cellRtcFormatRfc3339
 0x38BA5590 ccosl
 0xED773F5F cellSyncRwmWrite
 0xE6F5711B UTF16stoUTF8s
 0xA3D7EF1A cellTiffDecSetParameter
-0xC313A3A5 _ZN3paf10PhSaveData13SetLightColorEiRK4vec4
+0xC313A3A5 paf::PhSaveData::SetLightColor(int, vec4 const&)
 0x13C22F55 canonPrintGetPrinterInfo
 0xE5EA9E2B _Isdst
 0x7E5F23A4 FT_Tan
-0x4E48E271 _ZN3paf5Image6UnLoadEv
+0x4E48E271 paf::Image::UnLoad()
 0xF356418C open
 0x81F83DB9 cellCameraReset
 0x9E67E0DD cellSysutilApGetRequiredMemSize
 0x7CEC7B39 _Putfld
-0x28E3DF10 _ZN3paf14GraphicsMemory3MapEPvj
+0x28E3DF10 paf::GraphicsMemory::Map(void*, unsigned int)
 0xE413CD78 cellFsUtilDf
-0x884B021B _ZNKSt5ctypeIwE8_DowidenEc
+0x884B021B std::ctype<wchar_t>::_Dowiden(char) const
 0x0290C402 canonPrintGetPrintableArea
 0xE584836C _LPoly
 0xC324F60C cellMediatorCloseContext
-0xB9AA0DCF _ZN4xMMS15SetValuePointerEPvj15eMmsDbFieldTypeS0_j
+0xB9AA0DCF xMMS::SetValuePointer(void*, unsigned int, eMmsDbFieldType, void*, unsigned int)
 0x05893E7C cellUserTraceRegister
-0xB33EF042 _ZNSt8bad_castD0Ev
-0x085BFF4F _ZNSt15basic_streambufIwSt11char_traitsIwEE5_LockEv
+0xB33EF042 std::bad_cast::~bad_cast()
+0x085BFF4F std::basic_streambuf<wchar_t, std::char_traits<wchar_t>>::_Lock()
 0x359642A6 sceNpCommerceGetCategoryDescription
 0x25596F51 sys_mempool_get_count
 0xF7B1B2A0 cellExifGetField
@@ -4741,16 +4741,16 @@
 0xF9DAE72C setjmp
 0xDA31FC5D _FFpcomp
 0xDC7ED599 cellHttpClientSetPerPipelineMax
-0x62F52BB0 _ZNSt7_MpunctIwEC2ERKSt8_Locinfojb
+0x62F52BB0 std::_Mpunct<wchar_t>::_Mpunct(std::_Locinfo const&, unsigned int, bool)
 0x0E091C36 cellSaveDataUserListAutoSave
 0xD2610322 cellGcmSetPolygonStippleEnable
 0x64ABDB4D csinhl
 0x08D631C8 scePS2McIconSys_GetBgColor3
 0x8D42FAE9 _QN4cell5Daisy22ScatterGatherInterlockC1EPVNS0_16_AtomicInterlockEjPvPFiS5_jE
 0x4524CCCD cellGcmBindTile
-0xDC05D196 _ZmlRK4mat4S1_
+0xDC05D196 operator* (mat4 const&, mat4 const&)
 0xE1C9F675 sceNpBasicMarkMessageAsUsed
-0xA4438D60 _ZN3paf8PhXmItem11AnimIconSetERKNS_12SurfaceRCPtrINS_7SurfaceEEES5_RK4vec4iiiS8_iiiii
+0xA4438D60 paf::PhXmItem::AnimIconSet(paf::SurfaceRCPtr<paf::Surface> const&, paf::SurfaceRCPtr<paf::Surface> const&, vec4 const&, int, int, int, vec4 const&, int, int, int, int, int)
 0x7A33E82A cellMarlinDRMFinSession
 0xAA9635D7 strcat
 0x61D5F528 cellAvsetGetHWConfig
@@ -4759,10 +4759,10 @@
 0xFDB8F926 sys_net_free_thread_context
 0x3F2FD49C pafGuDepthBuffer
 0xAB4747B4 FT_Match_Size
-0xFC406066 _ZN3paf9PhNumSpin8SetStyleEif
-0x7789A015 _ZN3paf7PhMicon7SetLoopEff
+0xFC406066 paf::PhNumSpin::SetStyle(int, float)
+0x7789A015 paf::PhMicon::SetLoop(float, float)
 0x6660FC8D TlsGetValue
-0x6E6A92EB _ZN3paf23SetFormatStringCallbackEPFPKwwE
+0x6E6A92EB paf::SetFormatStringCallback(wchar_t const* (*)(wchar_t))
 0xDE8CEF62 SSL_do_handshake
 0x183BB11A Zi8GetCandidatesCount
 0x16BF208A log10f
@@ -4773,7 +4773,7 @@
 0xDB2E4DC2 sceNpScoreGetGameDataAsync
 0xEB201A52 sceSystemFileAddIndexW
 0x0A563878 cellVoiceStart
-0xB4E5D585 _Z16xcbGetPlugInDataPv
+0xB4E5D585 xcbGetPlugInData(void*)
 0x10B543D8 smf_ApPl_InitPlayStatus
 0xCB1E777F cellDtcpIpStartSequence
 0x17A3DA2C cellGcmSetVertexTexture
@@ -4785,13 +4785,13 @@
 0x5E4B0F87 cellSync2SemaphoreTryAcquire
 0xDF3E7FDB cellM4vEncQueryResource
 0xB1A2C38F cellVoiceInitEx
-0x2CC30288 _ZN3paf6PhFontD1Ev
-0x03159C56 _Z16xcbSetPlugInDataPvS_
+0x2CC30288 paf::PhFont::~PhFont()
+0x03159C56 xcbSetPlugInData(void*, void*)
 0xEDA48C80 malloc_trim
 0xED337B94 cellAvcEncSmallGetLocalDecodedFrame
 0xF3BD7D08 _cbrtf4fast
 0xBAEDF689 sceNpTrophyGetTrophyIcon
-0x01059AF3 _ZN3paf8PhXmList10SetKeyMaskEi
+0x01059AF3 paf::PhXmList::SetKeyMask(int)
 0x60EB2DEC cellSpursCreateJobChain
 0xA2858F66 cellMouseConfigInit
 0x43F98936 xSettingAudioGetInterface
@@ -4803,7 +4803,7 @@
 0xE8D86C43 cellSailProfileSetStreamParameter
 0x317AB7C2 UTF16toUTF8
 0x7F579E03 atan
-0x16E5D60E _ZN23xMMSMdGeneratorReceiver11GetInstanceEv
+0x16E5D60E xMMSMdGeneratorReceiver::GetInstance()
 0x1225DD31 casinf
 0x6CD0F95F cellRescSetSrc
 0x19BE84DB sceLoginServiceNetworkLogout
@@ -4811,25 +4811,25 @@
 0xE2ACCD6C cellTiffDecExtOpen
 0xD5FC3ED0 sceNpC7yScoreRecordScoreRequestVsh
 0x0E806058 sceNpC7yTusCreateTransactionVsh
-0x81027E75 _ZNSt7_MpunctIwE5_InitERKSt8_Locinfo
+0x81027E75 std::_Mpunct<wchar_t>::_Init(std::_Locinfo const&)
 0x70F3E728 cellFontSetScalePoint
 0xED5D96AF cellAudioOutGetConfiguration
 0x17CD5D87 _recipf4fast
 0x032CC709 csin
 0xC1BC3E57 sceNpUpdateClockAbort
-0xC0FAF91C _ZN4cell5Daisy22ScatterGatherInterlock21proceedSequenceNumberEv
+0xC0FAF91C cell::Daisy::ScatterGatherInterlock::proceedSequenceNumber()
 0x2C393B42 sceNpUnregisterCallbackExt
 0xD3A84BE1 cellVoiceStop
 0xB43C25C7 wcstoull
-0x40719C8C _ZN16sysutil_cxmlutil11FixedMemory3EndEi
-0x94F43BE7 _ZN3vsh13Infobar_CloseEb
+0x40719C8C sysutil_cxmlutil::FixedMemory::End(int)
+0x94F43BE7 vsh::Infobar_Close(bool)
 0xB45387CD cellCryptoPuAesCbcCfb128Decrypt
-0x007CAE46 _ZN29xMMSMdRelationResolveAccessor15ReleaseMetadataEPv
+0x007CAE46 xMMSMdRelationResolveAccessor::ReleaseMetadata(void*)
 0xF44C0E1D cellFsGetDirent
 0xC98A3146 inet_ntop
 0xACAD8FB6 sys_game_watchdog_clear
 0xB96FB26E cellPngDecGettRNS
-0xFE0C1F10 _ZN3paf15Job_CreateQueueEv
+0xFE0C1F10 paf::Job_CreateQueue()
 0x8F5DD179 _Nnl
 0x814D8CB0 fflush
 0x89B507B3 catanhl
@@ -4837,10 +4837,10 @@
 0xBA5961CA _cellSyncLFQueuePushBody
 0x38E8695C FT_MulFix
 0x000E53CC sceNpManagerSubSignout
-0xE2925302 _ZNK3paf7PhSPrim8GetStyleEiRb
+0xE2925302 paf::PhSPrim::GetStyle(int, bool&) const
 0xF6C6900C cellFiberPpuCheckFlags
 0x6595CE22 cellSubDisplayGetRequiredMemory
-0x26A34820 _ZN8PSJSHeap12private_freeEPv
+0x26A34820 PSJSHeap::private_free(void*)
 0x73F2CD21 SJISstoJISs
 0xA07C3D2F cellRtcFormatRfc2822LocalTime
 0x4E74D383 cellPostNrFinalize
@@ -4851,92 +4851,92 @@
 0x6514DBE5 wcstold
 0xCF1CBCF5 sceAdAsyncCloseContext
 0xFB764A9D canonPrintInitDriver
-0x9891BF45 _ZNKSt7_MpunctIwE16do_thousands_sepEv
+0x9891BF45 std::_Mpunct<wchar_t>::do_thousands_sep() const
 0x33ACD759 cellFsUtilUmount
 0xC25D60F0 FTFaceH_GetBoundingBoxHeight
 0x326FAB55 cellSysutilAvcExtGetNamePlateShowStatus
 0xA707820F xRegistryDestroy
 0xF06A6415 cellSyncBarrierNotify
-0x55481E6F _ZNSt15basic_streambufIwSt11char_traitsIwEE9showmanycEv
+0x55481E6F std::basic_streambuf<wchar_t, std::char_traits<wchar_t>>::showmanyc()
 0xD7F0AFAA FT_Vector_From_Polar
 0x453F9E91 cbrtf
 0xA01EE33A cellFsRegisterConversionCallback
 0xF233C864 cellGcmSetVertexTextureControl
-0xFBAD1D7A _ZN3paf8PhWidget18GetLayoutSizeValueEv
-0xA6F56DD8 _ZN3paf7PhSText7DestroyEv
+0xFBAD1D7A paf::PhWidget::GetLayoutSizeValue()
+0xA6F56DD8 paf::PhSText::Destroy()
 0xB980B76E cellSailMp4MovieGetBrand
 0x55D7BBFD cellSysutilAvc2MicRead
 0x889CCCB0 llroundl
-0xA3415D11 _ZN3paf10PhSPrimDiv6RenderEPKNS_8PhWidgetERK4vec4b
+0xA3415D11 paf::PhSPrimDiv::Render(paf::PhWidget const*, vec4 const&, bool)
 0x21425307 cellSaveDataListAutoLoad
-0x75A0617C _ZNKSt7_MpunctIwE11do_groupingEv
+0x75A0617C std::_Mpunct<wchar_t>::do_grouping() const
 0x8E6C5BB9 cellHttpUtilFormUrlDecode
 0xA46A70A1 atanhl
 0xBE6E5C58 spu_thread_read_uchar
-0x73715D20 _ZN4xMMS14CreateMetadataEPh15MmsMetadataTypePPv
-0x8D4E266B _ZNKSt8_Locinfo9_GetctypeEv
+0x73715D20 xMMS::CreateMetadata(unsigned char*, MmsMetadataType, void**)
+0x8D4E266B std::_Locinfo::_Getctype() const
 0x659775FB cellAtracMultiSetSecondBuffer
 0x11F1DCDB cellAvcEncGetVersion
 0x40D04E4E fwide
 0x3EF66B95 cellMouseClearBuf
-0x66F39ADB _ZNSt8numpunctIwED1Ev
+0x66F39ADB std::numpunct<wchar_t>::~numpunct()
 0xB229E6BF FT_Load_Glyph
-0x201528C1 _ZN3paf6PhText9ShowCaretEb
-0xCC8004C6 _ZN3paf5Sound6Output19ReleaseAudioChannelEi
+0x201528C1 paf::PhText::ShowCaret(bool)
+0xCC8004C6 paf::Sound::Output::ReleaseAudioChannel(int)
 0xA57CC615 iswspace
-0x061CAD23 _ZNK3paf7PhMicon10GetBGColorEv
+0x061CAD23 paf::PhMicon::GetBGColor() const
 0x48E5EAA9 naacEncGetBufferRequest
 0xDC2A512E cellSsUmGetExtractPackage
 0x55B4350B cellGcmSetFlipMode2
 0x7BF17B15 cellVoiceResumePort
 0x21D424F0 cellDmuxResetEs
 0x60FFA0EC GB18030stoUCS2s
-0x9BD8429E _ZN3vsh25ShowButtonNavigation_BackEb
+0x9BD8429E vsh::ShowButtonNavigation_Back(bool)
 0x96C07ADF cellSysmoduleFinalize
 0x86C864A2 cellSpursGetJobChainId
-0x4E5CD916 _ZNKSt8numpunctIwE11do_groupingEv
+0x4E5CD916 std::numpunct<wchar_t>::do_grouping() const
 0x2CCE9CF5 cellRtcGetCurrentClockLocalTime
 0x651FD79F sceNpTusGetMultiSlotDataStatusAsync
 0x7345B4BE _WStoll
-0xA379140B _ZN29xMMSMdRelationResolveAccessor17DeleteMetadataSetEjPy
+0xA379140B xMMSMdRelationResolveAccessor::DeleteMetadataSet(unsigned int, unsigned long long*)
 0x3B90102F pafGuSyncGpuAll
 0xF86531E0 sqlite3_column_text16
 0x395EF8D7 cellAuthDialogOpen
 0x5F62D546 cellAtracGetMaxSample
 0xFE9A6DD7 cellFontGetCharGlyphMetricsVertical
-0x48D101EF _ZNKSt8ios_base7failure8_DoraiseEv
+0x48D101EF std::ios_base::failure::_Doraise() const
 0x04E7499F cellDmuxSetStream
 0x4DED9F6C sys_dbg_signal_to_ppu_exception_handler
-0xA2108B85 _ZN3paf8PhWidget8GetStyleEiiRf
+0xA2108B85 paf::PhWidget::GetStyle(int, int, float&)
 0x1AEB33A5 FT_Bitmap_Embolden
 0xCF51864B sceNpDrmGetTimelimit
-0x398194FB _ZN3vsh3fim21friendResponseRequestEP7SceNpIdbPFiiPvES3_
-0x66977993 _ZN3paf7PhSTextC1ERNS_9PhSRenderEPS1_
-0x005B064D _ZN3vsh23sysutil_cxmlutil_server15MallocAllocatorEN4cxml14AllocationTypeEPvS3_jPS3_Pj
+0x398194FB vsh::fim::friendResponseRequest(SceNpId*, bool, int (*)(int, void*), void*)
+0x66977993 paf::PhSText::PhSText(paf::PhSRender&, paf::PhSRender*)
+0x005B064D vsh::sysutil_cxmlutil_server::MallocAllocator(cxml::AllocationType, void*, void*, unsigned int, void**, unsigned int*)
 0xD0958814 sceNpSignalingGetPeerNetInfoResult
 0x366CB5EB atx_free_encode
-0x493212DA _ZNSt8time_getIwSt19istreambuf_iteratorIwSt11char_traitsIwEEED0Ev
+0x493212DA std::time_get<wchar_t, std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>>::~time_get()
 0x7277D7C3 cellUsbPspcmSend
 0x03A142B9 cellFontGraphicsGetDrawType
-0x2DAA5A42 _ZTv0_n12_NSt9strstreamD1Ev
+0x2DAA5A42 virtual thunk to std::strstream::~strstream()
 0x5EE3BC26 cellSysutilAvcGetVoiceMuting
 0x2796FDF3 cellFsRmdir
 0xF9CCFF2A sceNpMatching2GetServerInfoVsh
 0x9D140351 _Destroytls
-0xA921D353 _ZN3paf8PhWidget6GetPosEPS0_RK4vec4
-0x1989F59C _ZNSt8ios_base17register_callbackEPFvNS_5eventERS_iEi
+0xA921D353 paf::PhWidget::GetPos(paf::PhWidget*, vec4 const&)
+0x1989F59C std::ios_base::register_callback(void (*)(std::ios_base::event, std::ios_base&, int), int)
 0x19726757 SSL_peek
 0x9886810C _FDnorm
 0x4DF84707 cellGcmSetConvertSwizzleFormat
 0x3ECDC98B FTC_Manager_Lookup_Face
 0xDF328827 sceNpInstallerGetGuestSignIn
 0xDC9462C5 cellVideoPlayerGetPlaybackStatus
-0x0BC08C57 _ZNKSt7collateIwE7do_hashEPKwS2_
+0x0BC08C57 std::collate<wchar_t>::do_hash(wchar_t const*, wchar_t const*) const
 0x66EA9546 sceNpC7yLookupInitVsh
 0x85DC6981 cellMediatorPostReports
 0xB2D4C7FC cellGcmSetScullControl
-0x3C997A99 _ZN12bXCeAttrList6LengthEv
-0xA957ADCC _ZNKSt5ctypeIcE9do_narrowEPKcS2_cPc
+0x3C997A99 bXCeAttrList::Length()
+0xA957ADCC std::ctype<char>::do_narrow(char const*, char const*, char, char*) const
 0x3BC69C3A InputDevice_GetKeyAssign
 0x4B9B85B4 pafGuSwapCount
 0xC9E2965F FT_Stream_New
@@ -4944,31 +4944,31 @@
 0x33F27F25 _FCdivcr
 0x5CD3CE2A cellGcmSetZpassPixelCountEnable
 0xAF18D499 GB18030toUCS2
-0x69EB7F9A _ZN3paf6PhSpin14ChangeSelectedEii
-0xA971E5A3 _ZN8cxmlutil8GetFloatERKN4cxml7ElementEPKcPf
+0x69EB7F9A paf::PhSpin::ChangeSelected(int, int)
+0xA971E5A3 cxmlutil::GetFloat(cxml::Element const&, char const*, float*)
 0x59D1629A sceNpEulaCheckEulaStatus
 0x4484A101 cellCryptoPuSha1HmacTransform
 0x7473970A cellSailSourceNotifyStopCompleted
 0x0D42E780 sceNpSetSubHandle
 0x5C273469 cellAsfCheckNeedMem
-0x98BB0131 _ZN13psjsname_impl6DecRefEv
+0x98BB0131 psjsname_impl::DecRef()
 0x6F564A3D _QN4cell5Daisy21LFQueue2GetPopPointerEPNS0_8LFQueue2EPij
 0x0B168F92 cellAudioInit
 0xF99DA2FC fabsf4
 0x84E8B238 SSL_want
 0x9E33AB8F cellScreenShotEnable
-0x867120A1 _ZN3paf16SaveDataResourceC1ERKSs
+0x867120A1 paf::SaveDataResource::SaveDataResource(std::basic_string<char, std::char_traits<char>, std::allocator<char>> const&)
 0xA7A0045A SSLCERT_get_issuer_name
 0x113B0BEA sys_dbg_get_ppu_thread_ids
-0x6CAEBFD9 _ZN3paf5PhWeb17RemoveAllCallbackEv
+0x6CAEBFD9 paf::PhWeb::RemoveAllCallback()
 0x31211F6B cellAudioMiscSetAccessoryVolume
 0x4DD03A4E cellSaveDataListAutoSave
 0x333AFF1A FTRenderBuf_SetupByScalePixel
-0x3806365F _ZN3paf8PhIPAddr10WidgetTypeEv
+0x3806365F paf::PhIPAddr::WidgetType()
 0xAEE75751 cellSysutilAvc2SetWindowSize
 0xF7A14A22 realloc
 0x1C9D5E5A cellSailSoundAdapterSetPreferredFormat
-0xD223286B _ZN3paf5PhWeb28SetHistoryEnumeratedCallbackEPFvPS0_PKwS3_E
+0xD223286B paf::PhWeb::SetHistoryEnumeratedCallback(void (*)(paf::PhWeb*, wchar_t const*, wchar_t const*))
 0xB9BC6207 cellSpursAttachLv2EventQueue
 0xD54D3FD9 cellGcmCgSetAttribOutputMask
 0x9DCBCB5D cellSpursAttributeEnableSystemWorkload
@@ -4978,14 +4978,14 @@
 0x560F717B sceNpClansLeaveClan
 0x2E69BB2A _FCosh
 0xBF9EEA93 sceNpLookupAvatarImageAsync
-0x2F73BC40 _ZNK3paf10PhSaveData11GetRotationEv
+0x2F73BC40 paf::PhSaveData::GetRotation() const
 0xE68E4744 FT_DivFix
 0x78E4590A acosh
-0x4C36ABBB _ZN3paf10PhItemSpin10WidgetTypeEv
+0x4C36ABBB paf::PhItemSpin::WidgetType()
 0xC1C507E7 cellFsAioRead
 0xF6ACD0BC cellGameGetBootGameInfo
 0x9638F766 cellHttpInitCookie
-0xA4B672EF _ZN23xMMSMdGeneratorReceiver13GetFieldIdForEPKcPj
+0xA4B672EF xMMSMdGeneratorReceiver::GetFieldIdFor(char const*, unsigned int*)
 0xD34A420D cellGcmSetZcull
 0x9A0E3C6E mvcDecGetVersion
 0x887EC484 sys_exit_x3
@@ -5002,30 +5002,30 @@
 0xBD473829 cellAsfParser2AStdGetFrameData
 0xBCE9B3D4 dlnaPrintGetPrintableArea
 0xBD75F78B cellAdecGetPcmItem
-0x76E846B2 _ZNSt15basic_streambufIwSt11char_traitsIwEE6xsputnEPKwi
+0x76E846B2 std::basic_streambuf<wchar_t, std::char_traits<wchar_t>>::xsputn(wchar_t const*, int)
 0x92D48677 cellAtracMultiGetInternalErrorInfo
 0xA8DC0EFA cellSysutilAvc2CreateWindow
 0x952B9925 cellGcmSetVertexDataArrayOffset
 0xBFE02694 sceNpC7yScoreGetRankingByNpIdRequestVsh
 0x4CEF342E cellFsAioWrite
-0xA562099C _ZNSt7num_getIcSt19istreambuf_iteratorIcSt11char_traitsIcEEED1Ev
+0xA562099C std::num_get<char, std::istreambuf_iterator<char, std::char_traits<char>>>::~num_get()
 0xC5C5EED3 cellAtracMultiGetSoundInfo
 0x17FB83C1 cellGifDecExtOpen
-0xAE95FD09 _Z28xcbUpdateProgressSkipContentPv
+0xAE95FD09 xcbUpdateProgressSkipContent(void*)
 0x5A41C10F cellGcmGetTimeStamp
 0xED5D8DD6 BIO_ctrl
 0xA50777C6 shutdown
-0x4BEE7BA9 _ZNSt8ios_base7failureD1Ev
-0xBCF4D026 _ZNK4cxml7Element7GetNameEv
+0x4BEE7BA9 std::ios_base::failure::~failure()
+0xBCF4D026 cxml::Element::GetName() const
 0x1221A1BF sceNpClansSearchByProfile
 0x361EDAEE npTrophyUtilTerm
 0xA4DD11CC cellWebBrowserConfigGetHeapSize
-0x409409AF _ZNSt13basic_filebufIcSt11char_traitsIcEE6setbufEPci
+0x409409AF std::basic_filebuf<char, std::char_traits<char>>::setbuf(char*, int)
 0x033D5BA0 sceNpMatchingCancelRequest
 0x23A2EDE6 cellOskDialogExtAddJapaneseOptionDictionary
 0xD01B570D cellGcmSetGraphicsHandler
-0x9196EEB8 _ZNK3paf6PhText15GetColumnOffsetEv
-0x73878BBE _ZN3paf11SplitStringEPSt6vectorISsSaISsEERKSsS5_j
+0x9196EEB8 paf::PhText::GetColumnOffset() const
+0x73878BBE paf::SplitString(std::vector<std::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::allocator<std::basic_string<char, std::char_traits<char>, std::allocator<char>>>>*, std::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, std::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, unsigned int)
 0x4B52553B ceapartment_CEDllMain
 0xE9946648 sceNpMatching2SignalingGetCtxOpt
 0x700E6223 cellFontGetRenderCharGlyphMetricsVertical
@@ -5037,44 +5037,44 @@
 0xB45F6C17 sceNpC7yLookupAbortVsh
 0xB1E0718B sceNpManagerGetAccountRegion
 0x508196B4 raw_spu_printf
-0x26E8E1CF _ZNKSt5ctypeIwE5do_isEPKwS2_Ps
+0x26E8E1CF std::ctype<wchar_t>::do_is(wchar_t const*, wchar_t const*, short*) const
 0x13CD17FB sceNetCtlDelHandlerSysUtil
 0xCFC2C3ED cellGcmSetTexture
 0x91A1BEAA cellFsSetDiscReadRetrySetting
-0x8760D5F5 _ZN12bXCeNodeList8FindItemEPh
+0x8760D5F5 bXCeNodeList::FindItem(unsigned char*)
 0x1B6643AC SSL_CTX_set_app_verify_cb
-0x727FEBB5 _Z28xcbGetDestinationContainerIdPvPx
+0x727FEBB5 xcbGetDestinationContainerId(void*, long long*)
 0xEC68442C cellSpursQueueGetDirection
 0x93D4AE69 cellGameGetList
-0xED87189C _ZNK3paf5PhWeb13GetFocusedUrlEv
+0xED87189C paf::PhWeb::GetFocusedUrl() const
 0x4E1A17A6 _cellSpursJobQueuePortPushBody
 0x6B413178 sys_dbg_get_ppu_thread_status
 0xD2671D11 sceNpMatching2SetRoomDataExternalVsh
 0x1904435E sceNpTusCreateTransactionCtx
 0x467B2193 sceWaveAudioSetFormat
 0x718C9629 PAF_Resource_DOMGetNodeData
-0xA0118D9E _ZN3paf6PhText14RemoveAllAttrsEv
+0xA0118D9E paf::PhText::RemoveAllAttrs()
 0x8BB03AB8 sys_game_board_storage_write
 0x5E00D433 _cellSync2QueueAttributeInitialize
-0xEE867D9F _ZN17xCBResultIterator6CancelEv
+0xEE867D9F xCBResultIterator::Cancel()
 0x381AE33E sys_dbg_get_event_queue_information
 0x3B27C780 sys_net_get_sockinfo
-0x75AA7373 _ZN4cxml8Document5WriteEPFiPKvjPvES3_
+0x75AA7373 cxml::Document::Write(int (*)(void const*, unsigned int, void*), void*)
 0x7313C78D cellHttpClientSetSslIdDestroyCallback
-0x9BE4BB91 _ZN17xCBResultIteratorD2Ev
+0x9BE4BB91 xCBResultIterator::~xCBResultIterator()
 0xB856B63F cellSysutilAvc2GetWindowString
 0x50762986 Zi8AddUDWordW
 0xFF05DD1F smvd2CancelDecode
 0x68BC4FF3 cellAudioOutRegisterCallback
-0x258359DF _ZNKSt7num_putIcSt19ostreambuf_iteratorIcSt11char_traitsIcEEE6do_putES3_RSt8ios_basece
-0x5AE2A0BE _Z20xcbReferSourceIdListPvPPKxPi
+0x258359DF std::num_put<char, std::ostreambuf_iterator<char, std::char_traits<char>>>::do_put(std::ostreambuf_iterator<char, std::char_traits<char>>, std::ios_base&, char, long double) const
+0x5AE2A0BE xcbReferSourceIdList(void*, long long const**, int*)
 0x8D84A77B cellGcmTransferScaleMode
 0xB312E53F cellVideoPlayerSetFileIoCallback
 0x9558ED08 lrintf
 0x8CFEF376 __tls_get_addr
 0x609080EC isspace_ascii
 0xACEE8542 cellGcmSetFlipImmediate
-0x7A200FA1 _ZNK3paf8PhCamera16GetVirtualScreenERfS1_S1_
+0x7A200FA1 paf::PhCamera::GetVirtualScreen(float&, float&, float&) const
 0x6B7D0D60 pafGuCgSetFragmentShader
 0x98340E57 sceNpCommerceCreateCtxVsh
 0xAC14B8E3 cellDtcpIpGetDecryptedData
@@ -5083,14 +5083,14 @@
 0x723BBC7E cellGcmGetVBlankCount
 0x944B28E8 sceNpMatching2SignalingCancelPeerNetInfo
 0xB9D2AD22 remquol
-0xECB11C5E _ZN3paf9PhNumSpin8SetStyleEiib
+0xECB11C5E paf::PhNumSpin::SetStyle(int, int, bool)
 0x589B5314 strncat
-0xAA1A8C53 _ZN3paf14GraphicsMemory4Area13AllocFromPoolENS0_10DeviceTypeEijPj
+0xAA1A8C53 paf::GraphicsMemory::Area::AllocFromPool(paf::GraphicsMemory::DeviceType, int, unsigned int, unsigned int*)
 0xC47BFF32 sqlite3_close
 0x10F73566 sceNetStunTerm
 0x42D04FC8 cellAvcEncReopen
 0x8549EE34 naacEncFlush
-0xC612A38E _ZNSt6_WinitD1Ev
+0xC612A38E std::_Winit::~_Winit()
 0x8B31F735 cellM4vEncCancelLocalDecodedFrame
 0x38426D25 _Wctombx
 0x39567781 sceNpTrophyInit
@@ -5102,17 +5102,17 @@
 0xFAA275A4 cellVideoOutGetScreenSize
 0x80065642 FTRenderBuf_GetRenderMetrics
 0x1656D49F cellSpursLFQueueAttachLv2EventQueue
-0xC88CA4B2 _ZN3paf12PhLevelMeter10WidgetTypeEv
+0xC88CA4B2 paf::PhLevelMeter::WidgetType()
 0x636DC89E cellJpgEncEncodePicture2
 0x5FAF802B cellSailMp4MovieGetTrackByIndex
-0xCDAFDF19 _ZNSt15basic_streambufIcSt11char_traitsIcEE9showmanycEv
-0x604FEC95 _ZNSt12out_of_rangeD1Ev
+0xCDAFDF19 std::basic_streambuf<char, std::char_traits<char>>::showmanyc()
+0x604FEC95 std::out_of_range::~out_of_range()
 0x54FC2032 _cellSyncLFQueueAttachLv2EventQueue
 0xC21EE635 sys_dbg_read_spu_thread_context
 0xF9A53F35 cellPrintOpenConfig
 0xA5979570 FTManager_FT_Memory
-0xF7BA51FD _ZNSt13basic_ostreamIwSt11char_traitsIwEED0Ev
-0xCBDF7130 _ZNK3paf7PhSText8GetStyleEiRb
+0xF7BA51FD std::basic_ostream<wchar_t, std::char_traits<wchar_t>>::~basic_ostream()
+0xCBDF7130 paf::PhSText::GetStyle(int, bool&) const
 0x91A0D079 cellM4hdEncClose
 0x3F62C759 sceNpMatching2Init
 0x20543730 cellMsgDialogClose
@@ -5120,17 +5120,17 @@
 0x143F46A4 cellSysutilAvcExtStopCameraDetection
 0x5BFD37BE _FCaddcc
 0x2677568C putchar
-0x4618F156 _ZN3paf10PhMenuList11SetSelectedEi
+0x4618F156 paf::PhMenuList::SetSelected(int)
 0xEFD00F54 cellGcmUnmapEaIoAddress
 0x3B210319 cellSearchGetContentInfoByOffset
 0x184A21DA FT_Get_PFR_Advance
 0x5D3992DD cellFiberPpuUtilWorkerControlSendSignal
 0xB3C1556E sceNpMatchingRegisterInvitationHandler
-0x32EF17EE _ZN4cxml8Document11WriteToFileEPKc
+0x32EF17EE cxml::Document::WriteToFile(char const*)
 0xBFC03768 cellKey2CharSetMode
 0x3FAD4311 InputDevice_GetOwnership
 0xEEBD35E2 cellFt2dBitBltSrc
-0x49DA8C5F _ZNKSt9money_getIwSt19istreambuf_iteratorIwSt11char_traitsIwEEE6do_getES3_S3_bRSt8ios_baseRNSt5_IosbIiE8_IostateERe
+0x49DA8C5F std::money_get<wchar_t, std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>>::do_get(std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>, std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>, bool, std::ios_base&, std::_Iosb<int>::_Iostate&, long double&) const
 0x03BECF3C _Defloc
 0xC15E657E spu_raw_sprintf
 0x37BB53A2 cellHttpUtilAppendHeaderValue
@@ -5157,17 +5157,17 @@
 0xD5ADC4B2 cpowl
 0x73D364D5 sys_netset_close
 0x974DF255 divx311DecDecodeAu
-0x04081C1E _ZN3paf8PhXmItem13SetLabelAlphaEfff
+0x04081C1E paf::PhXmItem::SetLabelAlpha(float, float, float)
 0x6AA76999 cellSpursJobChainUnsetExceptionEventHandler
 0x99C228FC roundl
-0xF00401D2 _ZNSt9basic_iosIcSt11char_traitsIcEED0Ev
-0x5127DCD1 _ZNSsC1Ev
+0xF00401D2 std::basic_ios<char, std::char_traits<char>>::~basic_ios()
+0x5127DCD1 std::basic_string<char, std::char_traits<char>, std::allocator<char>>::basic_string()
 0xD2DE9F18 cellMouseConfigSwapButton
 0xFB81C03E cellGcmGetMaxIoMapSize
 0x896E1BFD spu_thread_write_uchar
 0xF0AECE0D sys_prx_unload_module
 0xF33291EB sceNpScoreGetFriendsRanking
-0x5F6F3AD3 _ZNK11PSJSContext11GetUserDataEv
+0x5F6F3AD3 PSJSContext::GetUserData() const
 0xF83F8182 cellPadSetPressMode
 0x47055FEA cellSailRendererVideoFinalize
 0x4E153E3E cellSpursGetWorkloadInfo
@@ -5178,12 +5178,12 @@
 0xD632A727 cellHttpEndExternalCache
 0xF0E1471C cellSync2QueueGetDepth
 0x25C107E6 cellRescSetConvertAndFlip
-0xD80EA56E _ZN8cxmlutil13GetFloatArrayERKN4cxml7ElementEPKcPPKfPj
+0xD80EA56E cxmlutil::GetFloatArray(cxml::Element const&, char const*, float const**, unsigned int*)
 0xAD8E9AD0 _Initlocks
-0x96D1A97D _ZN3paf7PhMicon10SetBGColorERK4vec4
-0x86C66CFC _ZNSsD1Ev
+0x96D1A97D paf::PhMicon::SetBGColor(vec4 const&)
+0x86C66CFC std::basic_string<char, std::char_traits<char>, std::allocator<char>>::~basic_string()
 0x4CBD0593 cellGcmSetVertexProgramConstantsPointer
-0x99DB254A _ZNK3paf7PhSPrim8GetStyleEiR4vec4
+0x99DB254A paf::PhSPrim::GetStyle(int, vec4&) const
 0x7066DA81 xUSBMassGetInstance
 0xF05DF789 cellHttpUtilCopyUri
 0xF254768C sys_dbg_disable_floating_point_enabled_exception
@@ -5203,7 +5203,7 @@
 0xDE9FA7E0 atxenc_get_config_data
 0x01067E22 cellPamfStreamTypeToEsFilterId
 0x70F71871 _FCdivcc
-0x2166E819 _ZN3paf4View12PageActivateEPv
+0x2166E819 paf::View::PageActivate(void*)
 0x1C6E4DBB cellHttpUtilBuildRequestLine
 0xCCFF1284 cellDmuxResetStreamAndWaitDone
 0x0F721A9D _LCsubcc
@@ -5215,9 +5215,9 @@
 0x3A840AE3 snprintf
 0xADC0A4B2 cellHttpClientPollConnections
 0xF5313D34 ERR_peek_error
-0x186BCC94 _ZNSt8ios_base4InitD1Ev
+0x186BCC94 std::ios_base::Init::~Init()
 0xC26A0417 sqlite3_step
-0x7C3ACA85 _ZN3vsh10ScrollText12SetLayoutPosEiii4vec4
+0x7C3ACA85 vsh::ScrollText::SetLayoutPos(int, int, int, vec4)
 0xB369C9E3 cellCryptoPuRsavp11024
 0x2AAE9EF5 cellSaveDataFixedSave2
 0xC50303B2 cellVideoPlayerSetVolume
@@ -5234,7 +5234,7 @@
 0xF8935FE3 spu_thread_write_float
 0x0FFB4665 cellAtracMultiCreateDecoder
 0xDECE76A6 acosf
-0xF9E43DA2 _ZN3vsh12GetString_OKEv
+0xF9E43DA2 vsh::GetString_OK()
 0xF0F87A60 sceNpTrophyGetTrophyDetails
 0xAAFEC23E atxenc_get_sinusoid_encode_flag
 0x273B9711 sprintf
@@ -5242,17 +5242,17 @@
 0xAED82C21 cellSysutilAvcExtGetWindowAlpha
 0x5D0CA0E8 _sys_net_lib_sync_destroy
 0xD46148F5 naacEncGetDelay
-0x49F7D434 _ZNSt8numpunctIwED0Ev
+0x49F7D434 std::numpunct<wchar_t>::~numpunct()
 0x65336418 cellMicRemoveNotifyEventQueue
-0x3190DFE4 _ZN4cell5Daisy22ScatterGatherInterlockC1EPVNS0_16_AtomicInterlockEjPvPFiS5_jE
+0x3190DFE4 cell::Daisy::ScatterGatherInterlock::ScatterGatherInterlock(cell::Daisy::_AtomicInterlock volatile*, unsigned int, void*, int (*)(void*, unsigned int))
 0x568B2352 cellSpursSemaphoreGetTasksetAddress
-0xBD316983 _ZNSt8numpunctIcE5_InitERKSt8_Locinfo
+0xBD316983 std::numpunct<char>::_Init(std::_Locinfo const&)
 0xC5EEF17F sys_dbg_read_ppu_thread_context
 0x377E0CD9 cellAudioSetNotifyEventQueue
-0x5FCF36DD _ZN3vsh11ContentInfo6DeleteEff
+0x5FCF36DD vsh::ContentInfo::Delete(float, float)
 0xFA705F30 xRegistryDeleteKey
 0x6D9EBCCF cellJpgDecReadHeader
-0x17DD0A4E _ZNKSt7_MpunctIwE16do_negative_signEv
+0x17DD0A4E std::_Mpunct<wchar_t>::do_negative_sign() const
 0x315673F6 _Csubcc
 0x9EEE5387 truncate64
 0x53EB43A1 _Getpmbstate
@@ -5261,32 +5261,32 @@
 0xB3AFEE8B cellFsStReadGetRingBuf
 0x24510989 ERR_func_error_string
 0x9553AF65 cellSailFutureFinalize
-0xC06A4CD8 _ZNSt7_MpunctIwED1Ev
+0xC06A4CD8 std::_Mpunct<wchar_t>::~_Mpunct()
 0x8A35C887 cellFontEndGraphics
-0x301F3376 _ZN3paf10PhProgress11ChangeValueEffi
+0x301F3376 paf::PhProgress::ChangeValue(float, float, int)
 0x0D106A11 cellFontGetRenderScalePixel
 0x2DE54871 cellVoiceCreatePort
-0x883E1F16 _ZNKSt11logic_error8_DoraiseEv
-0x197FC348 _ZNSt7num_putIwSt19ostreambuf_iteratorIwSt11char_traitsIwEEED1Ev
+0x883E1F16 std::logic_error::_Doraise() const
+0x197FC348 std::num_put<wchar_t, std::ostreambuf_iterator<wchar_t, std::char_traits<wchar_t>>>::~num_put()
 0x2F87926F cellDtcpIpOpenContentEx
 0x2ED909DC sceNpMatching2AbortRequest
-0x5FD00911 _ZN3paf8PhWidget15SetSize_ontimerERK4vec4
+0x5FD00911 paf::PhWidget::SetSize_ontimer(vec4 const&)
 0x1A706BAF cellCryptoPuTdesCbcCfb64Decrypt
 0xFAE77B82 cellAsfGetStreamObjectInfo
 0xDC405507 cellHttpClientGetVersion
-0x00EDDB5B _ZN3vsh10OptionMenu8SetAlphaEf
+0x00EDDB5B vsh::OptionMenu::SetAlpha(float)
 0xE63EB964 cellMinisSaveDataListDelete
 0x17B93503 at3enc_get_version
 0xAD218FAF sceNpDrmIsAvailable
 0xB4E13C7A rafSetResolution
-0x853ACF0E _Z24x3USBMass_GetStorageInfoyPKcS0_P16_xUSBStorageInfo
+0x853ACF0E x3USBMass_GetStorageInfo(unsigned long long, char const*, char const*, _xUSBStorageInfo*)
 0xCF725EB1 sceNpRegetSigninTicket
 0x9EB25E00 strcoll
 0x05FD5858 cellAvsetGetHDMIAudioLayout1Output
-0x1AD29E49 _ZN3paf8PhScroll8SetValueEf
-0x4F2A97E5 _ZN4rectC1Ef
-0xAC90BC8F _ZN3paf18Job_GetNumOfThreadEPNS_9Job_QueueE
-0x7CAB64F4 _ZN8XMWIOCTLD1Ev
+0x1AD29E49 paf::PhScroll::SetValue(float)
+0x4F2A97E5 rect::rect(float)
+0xAC90BC8F paf::Job_GetNumOfThread(paf::Job_Queue*)
+0x7CAB64F4 XMWIOCTL::~XMWIOCTL()
 0x32658F00 InputDevice_Get
 0x5F9A65C7 _WStold
 0x7B79B6C5 cellCryptoPuAesCbcCfb128Encrypt
@@ -5295,7 +5295,7 @@
 0x4797D1FF cellAtracGetNextSample
 0x2A01013E cellVoiceCreateNotifyEventQueue
 0xA298CAD2 l10n_convert_str
-0x6A336A8C _ZNK3paf10PhSaveData16GetRotationSpeedEv
+0x6A336A8C paf::PhSaveData::GetRotationSpeed() const
 0x0EF85527 sceNpSignalingAddExtendedHandlerVsh
 0x2CBB6F53 f_hypotf
 0x6CA9EFD4 sceNpCommerce2DoDlListStartAsync
@@ -5329,15 +5329,15 @@
 0xD7D3CD5D cellHttpClientSetProxy
 0xF4E3CAA0 cellAudioOutGetState
 0xB91967BC cellAtracMultiGetLoopInfo
-0xA1DE25C2 _ZTv0_n12_NSt10ostrstreamD1Ev
+0xA1DE25C2 virtual thunk to std::ostrstream::~ostrstream()
 0x752E10C4 cellApostSrcProcess
 0x9A013AB4 cellMtpRecvData
 0x21206642 sceNpScoreGetRankingByRangeAsync
-0xED058E54 _ZN3paf4Cond4WaitEv
+0xED058E54 paf::Cond::Wait()
 0xE9AC8223 _LCmulcr
 0xD7764198 divx311DecGetNumOfPictures
 0x6C164B3B cellFiberPpuWaitSignal
-0x1CF6785D _ZSt9use_facetISt5ctypeIwEERKT_RKSt6locale
+0x1CF6785D std::ctype<wchar_t> const& std::use_facet<std::ctype<wchar_t>>(std::locale const&)
 0xBD28FDBF sceNpInit
 0x9F72ADD3 cellSpursJoinTaskset
 0x30AA96C4 cellSpursInitializeWithAttribute2
@@ -5349,36 +5349,36 @@
 0x8DEC0DE7 scePS2Icon_GetAnimationFrame
 0x054AAE63 _fdimf4
 0x8171C1CC EUCCNtoUTF8
-0x83BCA135 _ZNKSt11logic_error4whatEv
+0x83BCA135 std::logic_error::what() const
 0x24E9D8FC cellImeJpSetKanaInputMode
 0x32F994A1 cosf4fast
 0x0C515302 cellPngDecExtOpen
 0xB81CD66A mbrlen
 0x51C9D62B cellGcmSetDebugOutputLevel
 0x0D38E130 SSL_get_rbio
-0xA4F6A919 _ZThn8_NSdD1Ev
+0xA4F6A919 non-virtual thunk to std::basic_iostream<char, std::char_traits<char>>::~basic_iostream()
 0xBA3FF070 cellAvsetSetAudioActive
 0x82275C1C cellSpursAttributeSetMemoryContainerForSpuThread
-0x4A6A2F04 _ZN3paf8PhWidget12UpdateLayoutEb
+0x4A6A2F04 paf::PhWidget::UpdateLayout(bool)
 0x074DBB39 cellUsbdAllocateMemory
 0xA91EA22B FTRenderBuf_RenderGlyphImageVertical
 0x6F639AFB f_llroundf
 0x7A062D26 cellPngDecGetcHRM
 0xE0AFD1E6 cellMinisSaveDataAutoDelete
 0x9E9D7D42 cellPngDecExtSetParameter
-0xE90AF838 _ZN3paf10PhSaveData13SetFrameSpeedEf
+0xE90AF838 paf::PhSaveData::SetFrameSpeed(float)
 0x43838C2A _QN4cell5Daisy16LFQueue2PopCloseEPNS0_8LFQueue2EPFiPvjE
 0x7D8010A0 sceFimPresenceServiceTerm
 0x42778D66 cellMtpGetDeviceStatus
 0xA9B0C1D9 cellGameDataGetSizeKB
 0xDD724314 cellMicStart
 0xA60FF5C9 EucJpHan2Zen
-0x0275C3D5 _ZN9PSJSValue6AssignERK11PSJSContextP13PSJSValueImpl
-0x047ED5F3 _ZN13MmsMdAccessor11GetMetadataEyPP11MmsDbRecord
-0x6B2A00C5 _ZN3paf8PhWidget13SetLayoutSizeEiii4vec4
+0x0275C3D5 PSJSValue::Assign(PSJSContext const&, PSJSValueImpl*)
+0x047ED5F3 MmsMdAccessor::GetMetadata(unsigned long long, MmsDbRecord**)
+0x6B2A00C5 paf::PhWidget::SetLayoutSize(int, int, int, vec4)
 0x01BBF2E0 cellSpursJobQueueGetSpurs
-0x5B872B03 _ZN3paf5Image13SetCancelFuncEPFbPvES1_
-0x1535232D _ZNK3paf5PhWeb26IsNavigationStatusCompleteEv
+0x5B872B03 paf::Image::SetCancelFunc(bool (*)(void*), void*)
+0x1535232D paf::PhWeb::IsNavigationStatusComplete() const
 0xB4A54446 _Stofx
 0x155DE760 sceNpSignalingGetConnectionInfo
 0xAFEF640D sceNpBasicGetFriendListEntryCount
@@ -5391,12 +5391,12 @@
 0xB851AACF sceNpMatching2SetRoomMemberDataInternal
 0x5E89C269 FTManager_OpenMemFace
 0x5264AC5C PAF_Resource_DOMGetNodeChildByID
-0x523A54A6 _ZNK4cxml7Element12GetAttributeEiPNS_9AttributeE
+0x523A54A6 cxml::Element::GetAttribute(int, cxml::Attribute*) const
 0x6E9EB0DC sincosf4fast
-0xDD8E775C _ZNK3paf7Surface10GetPagePtrEi
-0xFB1E70A0 _ZN8cxmlutil9SetStringERKN4cxml7ElementEPKcS5_
+0xDD8E775C paf::Surface::GetPagePtr(int) const
+0xFB1E70A0 cxmlutil::SetString(cxml::Element const&, char const*, char const*)
 0x534DC541 sceNpUtilJidToNpRoomId
-0x2557E245 _ZN3paf8PhWidget10SetPostureERK4vec4S3_PS0_
+0x2557E245 paf::PhWidget::SetPosture(vec4 const&, vec4 const&, paf::PhWidget*)
 0xEFC45C20 PAF_Resource_ResolveRefWString
 0xD676552B sqlite3_set_authorizer
 0x759E0635 malloc
@@ -5404,18 +5404,18 @@
 0xFFBAE95E asctime
 0x4208BC69 FTFaceH_SelectCharMap
 0xB9ECE4C8 cellGcmSetBackPolygonMode
-0x1A00F889 _ZNSt9exceptionD2Ev
-0x05903101 _ZNKSt7collateIcE7do_hashEPKcS2_
+0x1A00F889 std::exception::~exception()
+0x05903101 std::collate<char>::do_hash(char const*, char const*) const
 0xD43A130E sceNpCommerce2DoCheckoutFinishAsync
 0x88902AC0 cellM4vEncSetEndPoint
 0xA94A075F cellDivXDrmFinishDecrypt
 0xC1B4BBB9 raw_spu_write_char
 0xE442FAA8 cellPadLddUnregisterController
-0xC35764DF _ZNK3paf9PhSRender8GetStyleEiRf
-0xAD484F91 _ZN3paf8PhWidget22HandleFocusSwitchEventEPNS_7PhEventE
+0xC35764DF paf::PhSRender::GetStyle(int, float&) const
+0xAD484F91 paf::PhWidget::HandleFocusSwitchEvent(paf::PhEvent*)
 0xF48C0548 xSettingNetGetInterface
 0x369FE03D cellSpursQueueGetEntrySize
-0x5C15972F _ZNSt13basic_ostreamIwSt11char_traitsIwEED1Ev
+0x5C15972F std::basic_ostream<wchar_t, std::char_traits<wchar_t>>::~basic_ostream()
 0x7B55F641 sceNetHttpXmlCreateTransaction
 0x28740582 _cellAudioSysSpuChainRemoveId
 0x892F2590 fegetround
@@ -5423,20 +5423,20 @@
 0x9ADE62E5 cellDtcpIpInitialize
 0x7189430B cellImeJpAllConfirm
 0x658D8982 npTrophyUtilGetNetTitleList
-0xEE3D6DD0 _ZN3paf8PhWidget13SetAppearanceEPNS_8PhAppearE
+0xEE3D6DD0 paf::PhWidget::SetAppearance(paf::PhAppear*)
 0xB6AF290E _WFrprep
-0xABD92BCC _ZNSt7collateIwE7_GetcatEPPKNSt6locale5facetE
+0xABD92BCC std::collate<wchar_t>::_Getcat(std::locale::facet const**)
 0x3E01CA80 cellFsUtilitySetupHdd10GBForLinux
 0x9C7028A5 spu_thread_write_uint
 0x820DAE1A cellPngDecDestroy
-0x6CB1A335 _ZNSt6locale5facet7_DecrefEv
+0x6CB1A335 std::locale::facet::_Decref()
 0x7FBD8376 sqlite3_bind_blob
 0xA1CD2220 smf_ApPs_GetMovieTimeScale
 0x33717C32 NP_GetMIMEDescription
 0x2CCE2184 ceapartment_CEDllCanUnloadNow
-0x6A6B90C9 _ZSt15set_new_handlerPFvvE
+0x6A6B90C9 std::set_new_handler(void (*)())
 0x3BD9CE0A fsync
-0x4DAF3FCF _ZNSt15basic_streambufIcSt11char_traitsIcEE6xsgetnEPci
+0x4DAF3FCF std::basic_streambuf<char, std::char_traits<char>>::xsgetn(char*, int)
 0xD0A5D727 cellGameUpdateCheckStartAsync
 0xDE7AB33D sceNpCommerce2DoProductCodeStartAsync
 0xFA46FD99 _QN4cell5Daisy22ScatterGatherInterlock7releaseEv
@@ -5449,11 +5449,11 @@
 0x0ABB318B cellSailDescriptorCreateDatabase
 0xB1CC0B07 sceNpMatching2AbortContextStartVsh
 0xF92217C5 cellHttpAuthCacheGetEntryMax
-0xEBB6E16F _ZN13PSJSValueImpl11NewFromPoolERK11PSJSContextP10PSJSObject
+0xEBB6E16F PSJSValueImpl::NewFromPool(PSJSContext const&, PSJSObject*)
 0xDA56BFAA cellHttpAuthCacheImport
-0xCC0D0938 _ZN3paf10PhItemSpin6CreateEib
+0xCC0D0938 paf::PhItemSpin::Create(int, bool)
 0xAB77019F fstat
-0xD6A5EB3F _ZN7bXCeDoc13GetChildNodesEP8bXCeNode
+0xD6A5EB3F bXCeDoc::GetChildNodes(bXCeNode*)
 0x1AB01EA8 truncate
 0x37F723F7 cellPamfReaderGetNumberOfStreams
 0x2706EAA1 sceNpScoreSetPlayerCharacterId
@@ -5464,16 +5464,16 @@
 0x9CAC2085 sceNpClansChangeMemberRole
 0x989129E7 Zi8DetachUWD_ZH
 0x46D1234A cellImeJpClose
-0x89D0D45D _ZN3vsh3fim12setMeCommentEPKc
+0x89D0D45D vsh::fim::setMeComment(char const*)
 0x0D86295D _LCaddcr
 0xDD3B27AC _sys_spu_printf_finalize
 0xD39A61E4 cellFsUtilitySetupHdd10GBForPs3
-0x984CE3D7 _ZNSt8numpunctIcED1Ev
+0x984CE3D7 std::numpunct<char>::~numpunct()
 0x76D94642 sceNpCommerceBrowseShopFinishVsh
 0x87BD650F cellFontGraphicsSetDrawType
 0x0B9ECB98 toupper_ascii
-0x8043F265 _ZN3paf9PhNumSpin16SetColor_ontimerERK4vec4
-0x22777290 _ZNSs7replaceEjjPKcj
+0x8043F265 paf::PhNumSpin::SetColor_ontimer(vec4 const&)
+0x22777290 std::basic_string<char, std::char_traits<char>, std::allocator<char>>::replace(unsigned int, unsigned int, char const*, unsigned int)
 0x13808972 wcstok
 0x975D4824 cellAuthDialogClose
 0x7B082FDD cellGcmSetVertexDataArrayFormat
@@ -5482,21 +5482,21 @@
 0x63219199 EUCKRtoUTF8
 0xA3DB855C cellRudpPollControl
 0x0E7BAC9E smf_ApPs_ReadFileProperty2
-0x9DEF39DE _ZN3paf5Image15SetGlobalOptionENS_15ImageOptionCodeEi
+0x9DEF39DE paf::Image::SetGlobalOption(paf::ImageOptionCode, int)
 0x203FBEA3 BIO_get_retry_reason
-0xD910072E _ZN3vsh3fim14registCallBackEv
-0xEF6C6834 _ZN3paf8PhWidget14SetLayoutStyleEiiif
-0xD72BCDCB _ZN4vec4C1ERK4vec2
+0xD910072E vsh::fim::registCallBack()
+0xEF6C6834 paf::PhWidget::SetLayoutStyle(int, int, int, float)
+0xD72BCDCB vec4::vec4(vec2 const&)
 0x26AE9FF8 sceNpMatching2SignalingGetConnectionInfo
 0xDEA09D91 sceNpOAuthVshGetAuthorizationCode
-0xFD846612 _Z6clamp4RK4vec4ff
+0xFD846612 clamp4(vec4 const&, float, float)
 0x8A5DBB58 cellWebComponentCreate
-0x14EBB064 _ZN3paf6PhList14GetPartsWidgetEi
+0x14EBB064 paf::PhList::GetPartsWidget(int)
 0xC3E1C200 sceUpdateDownloadSetBuildNum
 0x5D045671 cellGcmSetPolygonOffsetLineEnable
 0x9CA9FFA7 cellHddGameSetSystemVer
 0x50F8A377 sjvtdGetVersionNumber
-0x48F9FABB _Z23x3USBMass_GetDeviceInfoyP15_xUSBDeviceInfo
+0x48F9FABB x3USBMass_GetDeviceInfo(unsigned long long, _xUSBDeviceInfo*)
 0x5817B841 canonPrintEndJob
 0xC84EAA2B sceNpC7yScoreGetRankingByNpIdResultVsh
 0x4DED0C42 sceWaveAudioGetRestSample
@@ -5506,15 +5506,15 @@
 0x430309A1 ldexpf
 0x26F33146 sceNpCommerceGetProductCategoryStart
 0x51C73000 svc1dDecodePicture
-0x143048BF _ZNSt15basic_streambufIcSt11char_traitsIcEE7seekoffElNSt5_IosbIiE8_SeekdirENS4_9_OpenmodeE
+0x143048BF std::basic_streambuf<char, std::char_traits<char>>::seekoff(long, std::_Iosb<int>::_Seekdir, std::_Iosb<int>::_Openmode)
 0x39B40DF9 pafGuDrawBuffer
 0xA8D180E8 _Cbuild
-0x5EC145E2 _ZN4cxml8DocumentD1Ev
-0xB39C42DC _ZN3paf10PhItemSpin10SetTextureERKNS_12SurfaceRCPtrINS_7SurfaceEEEi
+0x5EC145E2 cxml::Document::~Document()
+0xB39C42DC paf::PhItemSpin::SetTexture(paf::SurfaceRCPtr<paf::Surface> const&, int)
 0x688B8AC9 _cellGcmFunc38
 0x633C3196 cellGemGetMagData
-0x65036474 _ZNK3paf6PhText12GetTextWidthEv
-0x97E53BCA _ZN3vsh22TextureAnimation_StartEPN3paf8PhWidgetEiifRNS_20TextureAnimationDataE
+0x65036474 paf::PhText::GetTextWidth() const
+0x97E53BCA vsh::TextureAnimation_Start(paf::PhWidget*, int, int, float, vsh::TextureAnimationData&)
 0x9E25C72D _cellFiberPpuSchedulerAttributeInitialize
 0xFFCF4DED smf_ApPs_GetSampleDesHndl
 0x4B2F301A _sys_tolower
@@ -5526,12 +5526,12 @@
 0xF5F7DDA8 towupper
 0x6C272124 cellSyncBarrierTryWait
 0x7FDCF73E wcscat
-0x002C338B _ZNKSt8time_getIcSt19istreambuf_iteratorIcSt11char_traitsIcEEE16do_get_monthnameES3_S3_RSt8ios_baseRNSt5_IosbIiE8_IostateEPSt2tm
-0x4569ABC3 _ZN3paf6PhText10InsertTextEjRKSbIwSt11char_traitsIwESaIwEE
+0x002C338B std::time_get<char, std::istreambuf_iterator<char, std::char_traits<char>>>::do_get_monthname(std::istreambuf_iterator<char, std::char_traits<char>>, std::istreambuf_iterator<char, std::char_traits<char>>, std::ios_base&, std::_Iosb<int>::_Iostate&, std::tm*) const
+0x4569ABC3 paf::PhText::InsertText(unsigned int, std::basic_string<wchar_t, std::char_traits<wchar_t>, std::allocator<wchar_t>> const&)
 0xD208F91D sceNpUtilCmpNpId
 0x671990F3 CEUSemaphore_create
 0x6E42C0DD sceNpSnsFbDestroyHandle
-0x5903BC00 _ZN3paf6PhListC1EPNS_8PhWidgetEPNS_8PhAppearE
+0x5903BC00 paf::PhList::PhList(paf::PhWidget*, paf::PhAppear*)
 0xBE5BE3BA cellPadSetSensorMode
 0xEE05B0C1 cellHttpClientGetUserAgent
 0xE1BD3587 fclose
@@ -5540,50 +5540,50 @@
 0x269A634B cellDtcpIpMoveOpenEx
 0x4830FAF8 cellSailRecorderStart
 0xE173BD90 npTrophyUtilCreateCtx
-0xDB5BF8B0 _ZN10bXCeParser23SkipIgnorableWhiteSpaceEb
+0xDB5BF8B0 bXCeParser::SkipIgnorableWhiteSpace(bool)
 0xD8703A3F sceNpOAuthVshCreateRequest
 0xC1C8737C _Getptoupper
 0x766D3CA1 cellSslCertGetNameEntryCount
 0xAE0D9D26 cellGcmSetZMinMaxControl
 0xA703A51D cellPadGetInfo2
 0x65444204 UCS2toMSJIS
-0xC3D24EB3 _ZNSt9basic_iosIwSt11char_traitsIwEED0Ev
+0xC3D24EB3 std::basic_ios<wchar_t, std::char_traits<wchar_t>>::~basic_ios()
 0x80FB0C19 sys_prx_stop_module
 0x71D53210 cellNetCtlNetStartDialogAbortAsync
 0x1970CD7E getpid
 0x6BD131F0 cellMouseGetDataList
 0xC7020F62 cellVideoOutSetGamma
 0xEB5F2544 sceNpCommerceGetProductName
-0x6C8DC459 _ZNKSt8bad_cast4whatEv
+0x6C8DC459 std::bad_cast::what() const
 0xA568DB82 spu_thread_read_ushort
 0xD9E960B2 naacEncGetAdifHeader
 0xF19C5E94 sincosf4
-0xB6A4D760 _ZNSt13basic_filebufIwSt11char_traitsIwEE7seekposESt4fposISt9_MbstatetENSt5_IosbIiE9_OpenmodeE
+0xB6A4D760 std::basic_filebuf<wchar_t, std::char_traits<wchar_t>>::seekpos(std::fpos<std::_Mbstatet>, std::_Iosb<int>::_Openmode)
 0x606F9F42 cellFsChangeFileSizeWithoutAllocation
 0xD62F5D76 cellFontDeleteGlyph
-0x736C5F22 _ZNSoD0Ev
+0x736C5F22 std::basic_ostream<char, std::char_traits<char>>::~basic_ostream()
 0xA56557B6 catan
 0xB2F21D3A sceSystemFileLoadAll2
 0x8B69F85A xSettingDateGetInterface
 0x752FA85E fmaxf4
 0x9AD7FBD1 sceNpSignalingGetLocalNetInfo
-0xF28D2811 _Z32xcbGetDestinationContainerRecordPvPS_
-0xCE8C6ABC _ZNSt8ios_base4InitC2Ev
-0x1F2E9F4E _ZNSt15basic_streambufIwSt11char_traitsIwEE9underflowEv
+0xF28D2811 xcbGetDestinationContainerRecord(void*, void**)
+0xCE8C6ABC std::ios_base::Init::Init()
+0x1F2E9F4E std::basic_streambuf<wchar_t, std::char_traits<wchar_t>>::underflow()
 0xAC0EF565 cellVoiceAdjustThreadPriority
 0x6E90DB7C cellGcmContinueFifo
-0x561CBD17 _ZN3paf7PhSText7IsReadyEv
-0x91A43901 _ZN4xMMS11CreateQueryEPPv
+0x561CBD17 paf::PhSText::IsReady()
+0x91A43901 xMMS::CreateQuery(void**)
 0x21B94163 cellGcmSetInvalidateVertexCache
 0x4AF23EFA cellUsbPspcmSendAsync
 0x8A85674D _cellSpursLFQueuePushBody
 0x62B36BCF UTF8stoMSJISs
 0xC4617DDC cellSailRecorderBoot
-0xAF27EE12 _ZN3paf6PhList12PopBackLabelEi
+0xAF27EE12 paf::PhList::PopBackLabel(int)
 0xB598A495 fmodl
-0x00C9AFA5 _ZN3paf8PhWidget14GetLayoutStyleEiiRiS1_S1_R4vec4
+0x00C9AFA5 paf::PhWidget::GetLayoutStyle(int, int, int&, int&, int&, vec4&)
 0x17DBE8B3 cellSysutilAvcJoinRequest
-0x275212A0 _ZN3paf10PhSPrimDiv8SetStyleEiRK4vec4
+0x275212A0 paf::PhSPrimDiv::SetStyle(int, vec4 const&)
 0xBD59BC75 FT_GlyphLoader_Rewind
 0x98F14FD9 pafGuGetVirtualScreenSurf
 0x2BDC5D6B cellMusicSetSelectionContext2
@@ -5594,32 +5594,32 @@
 0xF30AC754 sceNpAuthOAuthInit
 0xA4A5DDB4 cellUsbPspcmCancelBind
 0x774033D6 cellSearchEnd
-0xCEB85584 _ZN3vsh11ContentInfoC1EiPN3paf8PhWidgetES3_
+0xCEB85584 vsh::ContentInfo::ContentInfo(int, paf::PhWidget*, paf::PhWidget*)
 0x0D4FCF86 smf_ApRc_WriteMovieRes
 0x09F9E1A9 sceNpClansUpdateClanInfo
-0x929496B3 _Z26PSJS_BuildValueImpl_ObjectRK11PSJSContext
+0x929496B3 PSJS_BuildValueImpl_Object(PSJSContext const&)
 0x9C9605EE sys_rsxaudio_start_process
 0xA3ABFADB sceNpTusGetMultiSlotDataStatusVUser
 0x18A67FB5 sceNpOAuthVshAbortRequest
 0x16322DF1 cellFontGraphicsSetScalePixel
 0xBE11BEAA _wremove
 0xA4599CF3 cellFiberPpuWaitFlag
-0xFDCB65D3 _ZN3paf9ImageAttr12SetDecOptionENS_15ImageOptionCodeEi
+0xFDCB65D3 paf::ImageAttr::SetDecOption(paf::ImageOptionCode, int)
 0x8D7FFAF1 _WStopfx
-0xDA1B159A _ZNSt6_MutexD2Ev
+0xDA1B159A std::_Mutex::~_Mutex()
 0x3C09716B cellSailComposerNotifyCallCompleted
 0x60315DCA SSL_state_string_long
-0xB4449EDC _Z30xcbUpdateProgressFinishContentPv
+0xB4449EDC xcbUpdateProgressFinishContent(void*)
 0x3E908C56 cellSailAviMovieGetStreamByIndex
 0x51CCBE09 cellSysutilAvcExtLoadAsyncEx
 0xAE082411 FT_Stream_GetLongLE
 0x09CE84AC cellPhotoExportFromFile
-0x635166C3 _ZNKSt9money_putIwSt19ostreambuf_iteratorIwSt11char_traitsIwEEE6do_putES3_bRSt8ios_basewe
+0x635166C3 std::money_put<wchar_t, std::ostreambuf_iterator<wchar_t, std::char_traits<wchar_t>>>::do_put(std::ostreambuf_iterator<wchar_t, std::char_traits<wchar_t>>, bool, std::ios_base&, wchar_t, long double) const
 0x17316BEE log2
 0x519EBB77 floor
 0x3593A445 clog
 0x54F59807 EUCJPtoUCS2
-0xD6EE1090 _ZNKSt9money_getIcSt19istreambuf_iteratorIcSt11char_traitsIcEEE6do_getES3_S3_bRSt8ios_baseRNSt5_IosbIiE8_IostateERe
+0xD6EE1090 std::money_get<char, std::istreambuf_iterator<char, std::char_traits<char>>>::do_get(std::istreambuf_iterator<char, std::char_traits<char>>, std::istreambuf_iterator<char, std::char_traits<char>>, bool, std::ios_base&, std::_Iosb<int>::_Iostate&, long double&) const
 0xA8C16038 _FDsign
 0xD1C98AF5 sceNpAacCreateRequest
 0xFF3208FE smf_ApPs_GetAVCDecoderConfigInfo
@@ -5629,16 +5629,16 @@
 0x059B007C cellGcmSetVertexProgramConstants
 0x2B9AA0F5 _cellAudioCloseAdmin
 0x8692FCD2 cellOskDialogExtRegisterConfirmWordFilterCallback
-0x2C967AA1 _ZN4cell5Daisy4Lock18getNextHeadPointerEv
+0x2C967AA1 cell::Daisy::Lock::getNextHeadPointer()
 0xEEF51BE0 sceNpCommerce2ExecuteStoreBrowse
-0x168EA34B _ZNK3paf7PhScene14GetCameraCountEv
+0x168EA34B paf::PhScene::GetCameraCount() const
 0xC1EB3B92 sceNpCommerce2EmptyStoreCheckFinish
 0x47E9424A sceNpTusTryAndSetVariable
 0x3607BBF8 svc1dInitialize
-0x20B940B3 _Z9PSJS_Exitv
+0x20B940B3 PSJS_Exit()
 0xFDB828D0 FTFaceH_GetKerning
 0xF1A35C8C sceNpInstallerExecDownload
-0x2E8BE5E6 _ZN29xMMSMdRelationResolveAccessor15SetValuePointerEPvjS0_j
+0x2E8BE5E6 xMMSMdRelationResolveAccessor::SetValuePointer(void*, unsigned int, void*, unsigned int)
 0x3D2C0F77 FTC_Image_Cache_Lookup
 0xBEF20E62 smvd4ReleaseInstance
 0x32C61BDF cellSslCertGetSubjectName
@@ -5652,17 +5652,17 @@
 0x623CD2DC sceNpTrophyDestroyHandle
 0xBE3AF96E sceNpUtilCanonicalizeNpIdForPsp
 0xB2882D07 sceNetUpnpAddHandler
-0x6C8F62F7 _ZN3paf7PhXmBar19GetFocusedItemIndexEi
-0x0C96D94F _ZN3paf9PhHandler17HandleSystemEventEPNS_7PhEventE
+0x6C8F62F7 paf::PhXmBar::GetFocusedItemIndex(int)
+0x0C96D94F paf::PhHandler::HandleSystemEvent(paf::PhEvent*)
 0x547FB4A7 sinf4fast
 0xE769581A smf_ApPs_GetIPMPSystemData
 0xF5D9D571 sys_config_remove_service_listener
-0x9CB73EE0 _ZSt6_ThrowRKSt9exception
-0x6D483B7A _ZNSt12strstreambuf9pbackfailEi
+0x9CB73EE0 std::_Throw(std::exception const&)
+0x6D483B7A std::strstreambuf::pbackfail(int)
 0x2AF4B73B fmax
 0xF1F0E5DA cellSailComposerNotifySessionError
 0x018281A8 cellSailGraphicsAdapterGetFrame2
-0x94FA1F5B _ZNSt15basic_streambufIwSt11char_traitsIwEE5uflowEv
+0x94FA1F5B std::basic_streambuf<wchar_t, std::char_traits<wchar_t>>::uflow()
 0x24A3D413 sys_dbg_mat_set_condition
 0xC9FFC854 cellUsbdEnableWakeOn
 0x62CCC64A cellSailComposerGetEsUserAu
@@ -5677,11 +5677,11 @@
 0xF16568AF _FAtan
 0xD815DF3B sceNetMallocInternal
 0x5EE37927 _LErfc
-0x9FD2EEA9 _ZNSt8_LocinfoC2EiPKc
-0xB9A2282D _ZNSt15basic_streambufIcSt11char_traitsIcEE8overflowEi
+0x9FD2EEA9 std::_Locinfo::_Locinfo(int, char const*)
+0xB9A2282D std::basic_streambuf<char, std::char_traits<char>>::overflow(int)
 0x5E78D18E cellRtcSetConf
 0xA41EF7E8 cellGcmSetFlipHandler
-0xC5CD1ED0 _ZNK3paf7PhModel8GetFrameEv
+0xC5CD1ED0 paf::PhModel::GetFrame() const
 0xE6205D77 sceNpMatching2SignalingGetPingInfoVsh
 0x7EFD420A _Daysto
 0x28B4E2C1 cellPamfReaderSetStreamWithTypeAndIndex
@@ -5698,18 +5698,18 @@
 0x7C1BCF37 isalnum_ascii
 0xB059C38A cellGcmSetNopCommand
 0xAD09481B sendmsg
-0x01409785 _ZNKSt8time_getIwSt19istreambuf_iteratorIwSt11char_traitsIwEEE7_GetintERS3_S5_iiRi
+0x01409785 std::time_get<wchar_t, std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>>::_Getint(std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>&, std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>&, int, int, int&) const
 0x0CE13C6B cellNetCtlAddHandler
 0x18ECC741 cellSailRecorderStop
 0x60A5D81F SSLCERT_from_binary
 0x163DAFEB _QN4cell5Daisy4Lock15completeConsumeEj
 0x1CE88676 SSLCERT_NAME_ENTRY_get_info
 0x36D0A53C _cellSpursJobQueuePushJob2Body
-0x9EB7F788 _ZNK4vec4eqERKS_
+0x9EB7F788 vec4::operator== (vec4 const&) const
 0xC2E18DA8 sceNpTusDeleteMultiSlotVariableVUserAsync
 0xB37A85EE cellFsUtilityEraseHddData
 0x15910AE7 sceNpCommerceGetDataFlagStateVsh
-0x6B620D94 _ZN3paf6PhText9EraseTextEjj
+0x6B620D94 paf::PhText::EraseText(unsigned int, unsigned int)
 0x6122E000 SJIStoUTF8
 0x66F53C35 ATEgetPredictiveItems
 0xD1EC0B25 cellHttpClientGetHeader
@@ -5723,55 +5723,55 @@
 0x9EED8D14 sceNpMatching2GetMemoryInfoVsh
 0x1E9FD6BA _sinf4fast
 0x1CEDF8D0 FT_Done_Face
-0xE1654E20 _ZNK3paf8PhWidget15GetEditTextPartERi
+0xE1654E20 paf::PhWidget::GetEditTextPart(int&) const
 0xD7938B8D cellSailPlayerCreateDescriptor
 0x4D717F12 NP_Initialize
-0xD2BE66E6 _ZN4cell5Daisy22ScatterGatherInterlock5probeEj
+0xD2BE66E6 cell::Daisy::ScatterGatherInterlock::probe(unsigned int)
 0x32C78A6A sceNpBasicGetFriendPresenceByIndex
 0xE186DD71 sceUpdateDownloadInit
 0xB3D304B2 cellFontPatchWorks
 0x6356082E sceNpSignalingCreateCtx
 0xF6482036 cellSaveDataUserGetListItem
 0x006016DA cellAtracGetBitrate
-0xB80CA215 _ZNSt13basic_filebufIwSt11char_traitsIwEE5imbueERKSt6locale
-0x8DD3F7E7 _ZNK7bXCeDoc7GetTextEP8bXCeNode
+0xB80CA215 std::basic_filebuf<wchar_t, std::char_traits<wchar_t>>::imbue(std::locale const&)
+0x8DD3F7E7 bXCeDoc::GetText(bXCeNode*) const
 0x2B7BA4CA _Tlsset
-0x58F29B96 _ZN3paf8PhWidget8GetStyleEiiR4vec4
+0x58F29B96 paf::PhWidget::GetStyle(int, int, vec4&)
 0xFB5887F9 cellGemIsTrackableHue
-0x49D9DDAF _ZNKSt8numpunctIwE12do_falsenameEv
-0x9C1D60C4 _ZN3paf6Thread4JoinEv
+0x49D9DDAF std::numpunct<wchar_t>::do_falsename() const
+0x9C1D60C4 paf::Thread::Join()
 0xD417EEB5 _Stoull
 0x4D93E97C cellGcmCgGetEmbeddedConstantCount
 0xA8144A35 cellAvcEncOpenExt
-0x294779FB _ZNSt8ios_base4InitD2Ev
-0x769CD90E _ZN12bXCeNodeList7DestroyEv
+0x294779FB std::ios_base::Init::~Init()
+0x769CD90E bXCeNodeList::Destroy()
 0x5D345DE9 cellDmuxResetStream
 0xCA6324F0 Zi8DetachUWD
 0xB988502C cellRudpListen
 0x1C0E8AB6 vswscanf
-0xB0B677BC _ZN3vsh10ScrollText14SetLayoutStyleEiif
+0xB0B677BC vsh::ScrollText::SetLayoutStyle(int, int, float)
 0x35D3F688 creal
 0x9949BF82 cellGameDataExitBroken
-0x629B8531 _ZNKSt7num_putIwSt19ostreambuf_iteratorIwSt11char_traitsIwEEE5_IputES3_RSt8ios_basewPcj
-0x8AAC61B1 _ZN3paf10PhItemSpin7SetTextERKSbIwSt11char_traitsIwESaIwEEi
+0x629B8531 std::num_put<wchar_t, std::ostreambuf_iterator<wchar_t, std::char_traits<wchar_t>>>::_Iput(std::ostreambuf_iterator<wchar_t, std::char_traits<wchar_t>>, std::ios_base&, wchar_t, char*, unsigned int) const
+0x8AAC61B1 paf::PhItemSpin::SetText(std::basic_string<wchar_t, std::char_traits<wchar_t>, std::allocator<wchar_t>> const&, int)
 0x15EC0CCA cellCelpEncClose
 0xDA217D1F atanl
 0x7A18C2B9 cellImeJpCurrentPartConfirm
-0xF2EC7374 _ZN3paf5PhWeb15getWindowHeightEv
+0xF2EC7374 paf::PhWeb::getWindowHeight()
 0xEC43B983 _f_sqrtf
 0x05F1DC9E _FExp
 0xC94F6939 accept
 0x3AE8D802 cellSsUmInspectPackage
 0xE186F9AC cellSysutilPacketBegin
-0xE434952C _ZN3paf8PhWidget17GetLayoutPosValueEv
-0x055C1462 _ZNSt15basic_streambufIcSt11char_traitsIcEED1Ev
+0xE434952C paf::PhWidget::GetLayoutPosValue()
+0x055C1462 std::basic_streambuf<char, std::char_traits<char>>::~basic_streambuf()
 0xFD0E1CAC cellSysmoduleUnloadModuleEx
-0xEFC6EF88 _ZN10bXCeMemMgrC2Ev
+0xEFC6EF88 bXCeMemMgr::bXCeMemMgr()
 0xEABC3D00 GB18030toUTF8
 0x9CC0CF44 sceNpTusSetDataVUserAsync
 0x2D067448 ftruncate64
 0xD4D80EA5 cellVoiceSetMuteFlagAll
-0xE75F6E21 _ZNKSt12length_error8_DoraiseEv
+0xE75F6E21 std::length_error::_Doraise() const
 0x0CDA14BA cellFsWidgetRmdir
 0x5783A454 cellSailMp4MovieGetMovieInfo
 0x77A94FA7 FTFaceH_SetRenderEffectWeight
@@ -5780,14 +5780,14 @@
 0xEB6F95FB cellCameraCtrlExtensionUnit
 0xDCEC6671 scePS2OSD_SarchEntryNamePath
 0x2EFA7294 UTF16stoUTF32s
-0x51F323AA _ZN3paf8PhWidget12SetFocusAnimEii
+0x51F323AA paf::PhWidget::SetFocusAnim(int, int)
 0xE65867F4 cellSsUmUpdatePackage
 0x67032742 sceNetXmppSendRosterResponse
 0x12B5CE8A scePS2McIconSys_GetBgColor1
 0x0BAC90F2 cellAvsetDisableEvent
 0x67618BA2 FT_GlyphSlot_Own_Bitmap
 0xB72BC4E6 cellDiscGameGetBootDiscInfo
-0x23A168EA _ZNK3paf10PhSaveData13GetFrameSpeedEv
+0x23A168EA paf::PhSaveData::GetFrameSpeed() const
 0xFEB2E30E FT_Outline_Done_Internal
 0x8A2F159B console_getc
 0xFCDE8385 cellGcmSetFragmentProgramOffset
@@ -5796,11 +5796,11 @@
 0x881583C3 _SceAdecCorrectPtsValue_Celp8
 0xFD39AE13 sceNpBasicGetFriendPresenceByNpId
 0x94D51F92 cellVoiceStartEx
-0x9BE84C11 _ZN3vsh11ContentInfo7SetTextERKSbIwSt11char_traitsIwESaIwEEi
+0x9BE84C11 vsh::ContentInfo::SetText(std::basic_string<wchar_t, std::char_traits<wchar_t>, std::allocator<wchar_t>> const&, int)
 0xAC12AA49 cellCryptoPuRsasp11024CRT
 0x39EF81C9 f_fmaxf
 0x501D1814 FT_GlyphLoader_CheckPoints
-0x29C90B94 _ZNKSt8numpunctIcE16do_thousands_sepEv
+0x29C90B94 std::numpunct<char>::do_thousands_sep() const
 0x50CB806E sceNpMatching2GetRoomDataExternalListVsh
 0x4152669C scalbln
 0xAFD9A625 cimagf
@@ -5810,7 +5810,7 @@
 0x4C188CAA cellMusicGetContentsId
 0x39C173FB cellSpursGetSpuThreadGroupId
 0x0D90A48D UCS2stoSJISs
-0x233E39D1 _ZN3paf9PhNumSpin14SetLayoutStyleEiif
+0x233E39D1 paf::PhNumSpin::SetLayoutStyle(int, int, float)
 0x585269BC cellPngEncGetStreamInfo
 0xCCEC5E4E atx_flush_encode
 0xDE54E2FC cellGemReset
@@ -5819,9 +5819,9 @@
 0xC39173A4 _cellSpursJobQueuePort2CopyPushJobBody
 0x71293B71 _FLog
 0xF8D95C49 cellFreeType2Ex
-0xC3F7B60E _ZN3paf6PhList19PushBackLabelShadowEi
+0xC3F7B60E paf::PhList::PushBackLabelShadow(int)
 0x2B81FB7F readdir
-0xCA784678 _ZN3paf8PhXmItem12GetLineCountEi
+0xCA784678 paf::PhXmItem::GetLineCount(int)
 0x8A561D92 _sys_heap_free
 0xC1008335 xSettingMouseGetInterface
 0x04FF12AB epsonPrintInitDriver
@@ -5829,7 +5829,7 @@
 0x06C9F85B smvd4Discontinue
 0xD42904B7 fabsl
 0xD612FA16 _Sinh
-0xF51953F0 _Z13xcbReferTitlePvPPKcPi
+0xF51953F0 xcbReferTitle(void*, char const**, int*)
 0xBF5BF5EA lseek64
 0xA6463518 __rename
 0xE25C7B03 cellCameraRead2
@@ -5840,7 +5840,7 @@
 0xBD591197 cellSailFeederAudioInitialize
 0x4F3A5866 cellSsDrvAuthDiscChange
 0xB412A8DC _LDint
-0x30E297EA _ZNSt7_MpunctIcEC2ERKSt8_Locinfojb
+0x30E297EA std::_Mpunct<char>::_Mpunct(std::_Locinfo const&, unsigned int, bool)
 0xC01CF9BA FTFaceH_GlyphMetrics
 0x6A48D894 FT_Sfnt_Table_Info
 0x4911FF9C rand_int31_TT800
@@ -5850,13 +5850,13 @@
 0x8CB722D5 cellFsWriteWithOffset
 0xA6B180AC cellGcmGetReportDataLocation
 0x8A71132C remove
-0xADF743E4 _ZN3paf8PhWidget14SetPos_ontimerERK4vec4PS0_
+0xADF743E4 paf::PhWidget::SetPos_ontimer(vec4 const&, paf::PhWidget*)
 0x5751ACF9 _LDscale
-0x22BE98E4 _ZN3paf5PhWeb12SetOskResultEPKw
+0x22BE98E4 paf::PhWeb::SetOskResult(wchar_t const*)
 0x7C549350 _cellAudio_sharedMemory_mapInPPU
 0x16B9369D cellGcmSetTransferDataOffset
 0xD86380D8 cellSpursGetJobPipelineInfo
-0x20477524 _ZNK3paf6PhText13GetLineHeightEv
+0x20477524 paf::PhText::GetLineHeight() const
 0x9F70C475 cellVoiceDeletePort
 0x6E2AB18B sceNpCommerceGetCategoryName
 0xC7B45A19 _LFpcomp
@@ -5881,25 +5881,25 @@
 0x24FD32A9 sjishan2zen
 0xE70F874E cellSpursJobQueueAttributeSetGrabParameters
 0x191899D0 FT_Stream_ReadAt
-0x268C3EA5 _ZNKSt7_MpunctIwE13do_pos_formatEv
+0x268C3EA5 std::_Mpunct<wchar_t>::do_pos_format() const
 0x449317ED _Fopen
 0x0AA1B8DE FT_Vector_Rotate
 0x28BCCEC6 xEventHandlerGetInstance
-0xD830252C _ZNSt12strstreambuf5_InitEiPcS0_i
+0xD830252C std::strstreambuf::_Init(int, char*, char*, int)
 0x4E66D483 cellSpursDetachLv2EventQueue
 0x352D9BFD naacEncInit
 0x90C82BFC cellSpursInitializeForSpuSharing
 0xF0A73832 cellFsLsnRead2
 0xFDBBE469 cellMicGetDeviceIdentifier
 0x9FD61D8E sceAdAsyncFlushReports
-0x33587DAE _Z31x3USBMass_GetStorageInformationyP16_xUSBStorageInfo
+0x33587DAE x3USBMass_GetStorageInformation(unsigned long long, _xUSBStorageInfo*)
 0x8E785B97 sceNpClansRetrievePostedChallenges
 0x78200559 cellPadInfoSensorMode
 0xF5847AA3 sceNpGetSubHandleByPsHandle
 0x73E074C8 CEUQueue_enqueue
-0x34C6C205 _ZN3paf8PhXmItem8IconSizeERK4vec4ffiii
+0x34C6C205 paf::PhXmItem::IconSize(vec4 const&, float, float, int, int, int)
 0x52696620 sys_crash_dump_get_user_log_area
-0x703117AD _ZN3paf7PhXmBar10WidgetTypeEv
+0x703117AD paf::PhXmBar::WidgetType()
 0xD79D5840 sceNpC7yScoreGetGameDataResultVsh
 0x87AE5A06 smvd4GetSideInfoSeq
 0xF7A19060 cellFontGetScalePoint
@@ -5910,34 +5910,34 @@
 0xD40723D6 fread
 0xA849D0A7 cellSailPlayerOpenEsUser
 0x9EC52258 BIG5toUCS2
-0x5949408E _ZNSt8ios_base5_TidyEv
+0x5949408E std::ios_base::_Tidy()
 0xD56B3C5C FT_Stream_Read
 0x9E4FC70D smf_ApPs_GetFileProfileInfo
 0x190912F6 cellFsStReadGetCurrentAddr
-0x605131D5 _ZNSt8_LocinfoC1EPKc
+0x605131D5 std::_Locinfo::_Locinfo(char const*)
 0x35BBDAD2 _cellSyncLFQueueCompletePushPointer2
-0xA464C70A _ZNKSt9money_putIwSt19ostreambuf_iteratorIwSt11char_traitsIwEEE6do_putES3_bRSt8ios_basewRKSbIwS2_SaIwEE
-0x2A384E95 _ZN10PSJSObjectnwEj
-0xB509AB64 _ZNSt10moneypunctIcLb1EED1Ev
+0xA464C70A std::money_put<wchar_t, std::ostreambuf_iterator<wchar_t, std::char_traits<wchar_t>>>::do_put(std::ostreambuf_iterator<wchar_t, std::char_traits<wchar_t>>, bool, std::ios_base&, wchar_t, std::basic_string<wchar_t, std::char_traits<wchar_t>, std::allocator<wchar_t>> const&) const
+0x2A384E95 PSJSObject::operator new(unsigned int)
+0xB509AB64 std::moneypunct<char, true>::~moneypunct()
 0x77BD901A cellAtracMultiGetNextSample
-0x900D1FA4 _ZNSt8time_putIwSt19ostreambuf_iteratorIwSt11char_traitsIwEEED0Ev
+0x900D1FA4 std::time_put<wchar_t, std::ostreambuf_iterator<wchar_t, std::char_traits<wchar_t>>>::~time_put()
 0x9E2BE0D3 cellDivXDrmPrepareDecrypt
 0xB75B2E7B sqlite3_reset
 0xCA0EA996 sceNpCommerce2GetCategoryContentsGetResult
 0x72CF95FC FT_Set_Debug_Hook
-0xBD89CC93 _ZN3paf5Image10SetSubRectERKNS_9ImageRectE
+0xBD89CC93 paf::Image::SetSubRect(paf::ImageRect const&)
 0x344ECA7E _WGetstr
 0xF4CF5435 FTC_Manager_Done
-0xC051D361 _ZN3paf9PhHandler16HandleStateEventEPNS_7PhEventE
-0x75975EB4 _ZNSsC1EPKc
-0xBF7FBF01 _ZNK9PSJSValue7IsClassEPKt
+0xC051D361 paf::PhHandler::HandleStateEvent(paf::PhEvent*)
+0x75975EB4 std::basic_string<char, std::char_traits<char>, std::allocator<char>>::basic_string(char const*)
+0xBF7FBF01 PSJSValue::IsClass(unsigned short const*) const
 0x970A3432 cacosh
 0x02170D1A cellDmuxQueryEsAttr
 0xD52B1C5F sceNpSetMyLanguages
-0x003745F4 _ZN13bXCeXMLParser6ResumeEh
-0xADB3E294 _ZN4xMMS14CancelGenerateEP19xMMSGenerateContext
+0x003745F4 bXCeXMLParser::Resume(unsigned char)
+0xADB3E294 xMMS::CancelGenerate(xMMSGenerateContext*)
 0xEE3B604D cellFiberPpuInitializeScheduler
-0x738BAAC0 _ZN3paf8PhWidgetD2Ev
+0x738BAAC0 paf::PhWidget::~PhWidget()
 0xEEF75113 _sys_toupper
 0xFF036800 cpowf
 0x06C53986 cellFsUtilityGetFsInfoSize
@@ -5951,22 +5951,22 @@
 0x0791015F cellGameUpdateCheckStartAsyncEx
 0x58D88914 cellFt2dPermuteComponent
 0xE0719847 sceNpTusDeleteMultiSlotData
-0x5102AC61 _ZNKSt7_MpunctIwE14do_curr_symbolEv
+0x5102AC61 std::_Mpunct<wchar_t>::do_curr_symbol() const
 0x1365B52A fcntl
 0x3574D37D _Wcsxfrmx
 0x3B5489A9 _Unwind_Resume
 0x01D5F161 SSL_set_session
-0x84023C03 _ZSt12setprecisioni
+0x84023C03 std::setprecision(int)
 0x5D1D7803 sceNetCtlConnectVsh
 0x0884FC95 sceNpMatching2RegisterLobbyEventCallback
-0x24A5BD6B _ZN3paf8PhButton10WidgetTypeEv
+0x24A5BD6B paf::PhButton::WidgetType()
 0x05F214E0 FTFaceH_GetMaxVerticalAdvance
-0x66603923 _ZN10PSJSObject7SetAttrEiRK9PSJSValue
+0x66603923 PSJSObject::SetAttr(int, PSJSValue const&)
 0x05D821C4 _Stoullx
-0x3F4844B4 _ZN3paf8PhWidget11EndEditTextEv
+0x3F4844B4 paf::PhWidget::EndEditText()
 0xF8B1AB0C cellAtracMultiIsSecondBufferNeeded
 0x1A91874B cellWebBrowserConfigSetFullScreen2
-0x1B46E880 _ZN13MmsMdAccessor17InsertMetadataSetEjPP11MmsDbRecordPy
+0x1B46E880 MmsMdAccessor::InsertMetadataSet(unsigned int, MmsDbRecord**, unsigned long long*)
 0xEDEC777D _Ttotm
 0x71A8472A sys_get_random_number
 0x4AE52DD3 exp2
@@ -5974,20 +5974,20 @@
 0xA6B5FC54 cellGcmSetDrawBegin
 0xA42AC07A cellMicOpenRaw
 0xC48D5002 cellRtcConvertUtcToLocalTime
-0x4F3E14A7 _ZN3paf8PhWidget18HandleKeycodeEventEPNS_7PhEventE
+0x4F3E14A7 paf::PhWidget::HandleKeycodeEvent(paf::PhEvent*)
 0x78BA5C41 cellAtracSetLoopNum
 0x16394A4E _cellSpursTasksetAttributeInitialize
 0x2EA94661 cellRescSetFlipHandler
 0x8B60C469 cellOskDialogExtUpdateInputText
 0x801DB596 cellVideoPlayerClose
 0xEC9E7CB9 spu_thread_read_llong
-0x2F8B3B85 _ZN3paf10PhSPrimDivC1ERNS_9PhSRenderE
+0x2F8B3B85 paf::PhSPrimDiv::PhSPrimDiv(paf::PhSRender&)
 0x2F9EB543 UTF8toEUCKR
 0x0CF9B8BD _Erfc
 0x9B52F2D1 FT_GlyphSlot_Embolden
 0x4056C932 cellSysutilAvcSetVoiceMuting
-0xCAC83A05 _ZNSt6locale7_LocimpC2Eb
-0x534AC5C4 _ZN3paf7PhXmBar11SetTopAlphaEfff
+0xCAC83A05 std::locale::_Locimp::_Locimp(bool)
+0x534AC5C4 paf::PhXmBar::SetTopAlpha(float, float, float)
 0x4345A7C1 SSLCERT_get_notBefore
 0xAFABAB6D init
 0xB6A6AD5A FTFaceH_GetBoundingBoxMaxY
@@ -5997,25 +5997,25 @@
 0x7BE47E61 sceNpScoreCensorCommentAsync
 0xD78744B4 TLSv1_client_method
 0x001074D0 cellSysutilAvcExtIsMicAttached
-0x22C482F2 _ZN3paf13AVCopyControlC1Ev
+0x22C482F2 paf::AVCopyControl::AVCopyControl()
 0xF5363608 sceNpTusDeleteMultiSlotVariableAsync
 0x0CE278FD UCS2stoHZs
 0x657FCD36 cellUsbPspcmInit
-0xD02C89C9 _ZN3paf7WebCore10InitializeEPNS_10HeapMemoryE
+0xD02C89C9 paf::WebCore::Initialize(paf::HeapMemory*)
 0xA285139D sys_spinlock_lock
 0xBBD4582F _Setloc
-0x7EF048AB _ZN3paf8PhWidget8GetStyleEiRf
-0xB6A7BA7A _ZNSt7num_getIwSt19istreambuf_iteratorIwSt11char_traitsIwEEED0Ev
+0x7EF048AB paf::PhWidget::GetStyle(int, float&)
+0xB6A7BA7A std::num_get<wchar_t, std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>>::~num_get()
 0x6AC91DE3 cellPngEncReset
 0xFE88E97E fscanf
 0xF4E8D559 smvd2GetBnrData
-0x19535F4C _ZN3vsh10ScrollText13SetLayoutSizeEiii4vec4
+0x19535F4C vsh::ScrollText::SetLayoutSize(int, int, int, vec4)
 0x48157605 _f_llrintf
 0x69793952 cellSailPlayerUnsubscribeEvent
 0x168A3117 sceNpBasicAddPlayersHistory
-0xB74F7B8F _ZNSt6locale7_LocimpC2ERKS0_
+0xB74F7B8F std::locale::_Locimp::_Locimp(std::locale::_Locimp const&)
 0x627A7BB9 atx_init_encode
-0x229A0963 _ZNKSt5ctypeIwE5do_isEsw
+0x229A0963 std::ctype<wchar_t>::do_is(short, wchar_t) const
 0xA2A344A7 cellFt2dClose
 0xB4D112AF cellFontGlyphGetVertexesGlyphSize
 0x806FD281 isblank_ascii
@@ -6025,7 +6025,7 @@
 0xFF3626FD cellAudioRemoveNotifyEventQueue
 0x0C4CB439 cellSailFutureReset
 0x2099F86E cellCelp8EncEncodeFrame
-0xA2C876E8 _ZN3paf8PhXmList19SetFocusOutTopColorERK4vec4ff
+0xA2C876E8 paf::PhXmList::SetFocusOutTopColor(vec4 const&, float, float)
 0xAABEB869 cellHttpUtilSweepPath
 0x527C6439 cellGcmTerminate
 0xAC6FC404 sys_ppu_thread_unregister_atexit
@@ -6037,19 +6037,19 @@
 0x5BEBB477 cellAsfReadData
 0x9822DAE2 sceNpMatching2RegisterLobbyMessageCallbackVsh
 0x6E05231D sys_game_watchdog_stop
-0x16E0B7A4 _ZN7bXUtils7DestroyEv
+0x16E0B7A4 bXUtils::Destroy()
 0x7B5AAC20 spu_thread_write_ptr
 0xBF6E3659 cellHttpClientSetRecvBufferSize
 0xA755B005 cellHttpSendRequest
-0x3A8D0E1C _ZN3vsh13MessageDialog16SetDeleteHandlerEPFvPvES1_
+0x3A8D0E1C vsh::MessageDialog::SetDeleteHandler(void (*)(void*), void*)
 0x0DF25834 sceNpClansRetrieveChallenges
-0x25D7B3B3 _ZN3paf7PhMicon7SetCropERK4rect
+0x25D7B3B3 paf::PhMicon::SetCrop(rect const&)
 0x8D1FF475 cellSailRendererVideoInitialize
 0x6ACAC985 sceNpManagerSignout
 0x68C6AA3F sjvtdGetExistenceFlag
 0x09A4A040 cellJpgEncCoreDestroy
-0x7D23AA12 _ZNSt10moneypunctIwLb0EE7_GetcatEPPKNSt6locale5facetE
-0x1F31959E _ZN3paf10MessageBox25SetQueryButtonInfoHandlerEPFbNS0_10ButtonTypeEPNS0_10ButtonInfoEE
+0x7D23AA12 std::moneypunct<wchar_t, false>::_Getcat(std::locale::facet const**)
+0x1F31959E paf::MessageBox::SetQueryButtonInfoHandler(bool (*)(paf::MessageBox::ButtonType, paf::MessageBox::ButtonInfo*))
 0xB53436E7 _cellSpursJobQueuePort2PushJobListBody
 0xA4E6C423 FT_Select_Charmap
 0xFB6E6213 log1pf4fast
@@ -6069,14 +6069,14 @@
 0xE40E3DFC cellSysutilAvc2GetScreenShowStatus
 0xC5D63632 smf_ApPs_GetBrand
 0x76BC4FDF cellAvcEncSmallClose
-0xEA5516A5 _ZN3vsh3fim4initEv
+0xEA5516A5 vsh::fim::init()
 0x18D0ADA6 cellAudioOutGetDeviceInfo2
-0x85BA062F _ZNSt15basic_streambufIcSt11char_traitsIcEE7_UnlockEv
-0x3F5AB405 _ZN3paf6PhList12GetShowStateEi
-0xB6584CE7 _ZN3paf7PhSPrim8SetStyleEib
+0x85BA062F std::basic_streambuf<char, std::char_traits<char>>::_Unlock()
+0x3F5AB405 paf::PhList::GetShowState(int)
+0xB6584CE7 paf::PhSPrim::SetStyle(int, bool)
 0x4A9C874B sceSystemFileLoadAll
-0xA9116516 _ZNSs6appendEjc
-0x1BCCD2CA _ZNKSt8time_getIcSt19istreambuf_iteratorIcSt11char_traitsIcEEE7_GetintERS3_S5_iiRi
+0xA9116516 std::basic_string<char, std::char_traits<char>, std::allocator<char>>::append(unsigned int, char)
+0x1BCCD2CA std::time_get<char, std::istreambuf_iterator<char, std::char_traits<char>>>::_Getint(std::istreambuf_iterator<char, std::char_traits<char>>&, std::istreambuf_iterator<char, std::char_traits<char>>&, int, int, int&) const
 0x6636C4A5 frexpf
 0xB6BCB4A1 cellRudpEnd
 0xFF9D259C cellRudpGetOption
@@ -6086,7 +6086,7 @@
 0xAB447704 sys_net_open_dump
 0x59394806 FT_Done_Memory
 0x66F5E388 cellRescGetLastFlipTime
-0xEE05CF53 _ZN3paf10PhInfoList6CreateEif
+0xEE05CF53 paf::PhInfoList::Create(int, float)
 0x7B9DDCBC mios2_Client_SendBlocking
 0x38EA9A58 Pool_Alloc
 0xB54CC9A1 f_sinf
@@ -6096,19 +6096,19 @@
 0x658806BD sceNpUpdateClockTerm
 0x345C225A sceAdCacheSpacesCancel
 0x242C603E _Frprep
-0xF584DE56 _ZNSt6locale7_Locimp8_MakelocERKSt8_LocinfoiPS0_PKS_
+0xF584DE56 std::locale::_Locimp::_Makeloc(std::_Locinfo const&, int, std::locale::_Locimp*, std::locale const*)
 0x49D18217 sceNpTrophyGetGameInfo
 0xC0AB392E sceNpC7yScoreGetRankingByRangeRequestVsh
 0x146618DF sceNpCommerce2GetProductInfoListGetResult
-0xC6EA0FD0 _ZNSt6locale7classicEv
+0xC6EA0FD0 std::locale::classic()
 0x7E7017B1 rmdir
 0x744680A2 sys_initialize_tls
 0xBB5C565B cellCameraStopPost
-0xC94E8621 _ZN3paf7PhXmBar8SelectInEfffi
-0x7BAAD6D1 _ZN3paf7PhXmBar8HideFadeEff
+0xC94E8621 paf::PhXmBar::SelectIn(float, float, float, int)
+0x7BAAD6D1 paf::PhXmBar::HideFade(float, float)
 0x4CC9B68D cellPadPeriphGetInfo
 0x4343139D sceNpInstallerTellFriend
-0x79A415F8 _ZNSbIwSt11char_traitsIwESaIwEE6insertEjjw
+0x79A415F8 std::basic_string<wchar_t, std::char_traits<wchar_t>, std::allocator<wchar_t>>::insert(unsigned int, unsigned int, wchar_t)
 0x30D1CBDE sceNpBasicGetMessageEntry
 0xF6A68A30 cellGcmFlush
 0x74311398 sys_prx_get_my_module_id
@@ -6121,12 +6121,12 @@
 0xB569849D reallocalign
 0xAFA1DB9B cellAvcEncCancelAuInfo
 0xA03EF587 cellGemPrepareCamera
-0xD29BE6FF _ZN34xMMSMdStorageMediaGenerateProducer11GetInstanceEv
+0xD29BE6FF xMMSMdStorageMediaGenerateProducer::GetInstance()
 0x77CDAC0C _cellSpursSemaphoreInitialize
-0x0A1DC401 _ZN3paf4View12SetInterfaceEiPv
+0x0A1DC401 paf::View::SetInterface(int, void*)
 0x8FAB7348 cellPadConfigSetLed
-0x265FCA0C _ZN4xMMS16DestroySortChainEPv
-0x522B0457 _ZNSt10istrstreamD0Ev
+0x265FCA0C xMMS::DestroySortChain(void*)
+0x522B0457 std::istrstream::~istrstream()
 0xDD92118E ceill
 0xA77A90BC sceNpGetUserIconByPsHandle
 0xCF11C3D6 cellRtcParseRfc3339
@@ -6136,23 +6136,23 @@
 0x745DB631 cellMarlinUtilityInitialize
 0xC5DEE254 cellSync2SemaphoreInitialize
 0xD3AD63E4 cellScreenShotSetParameter
-0xB361BDA6 _ZN3paf8PhIPAddr8GetValueEPhi
+0xB361BDA6 paf::PhIPAddr::GetValue(unsigned char*, int)
 0x6C54092D cellPadConfigEnd
 0x5EC05AD8 sceNpEulaAbort
 0x9F0D254E cellMp3EncEncode
 0xAF002043 independent_comalloc
 0xCC946D56 sceNpScoreGetFriendsRankingAsync
-0x9BA3E97F _Z29_sce_np_sysutil_cxml_set_npidRN4cxml8DocumentERNS_7ElementEPKcPK7SceNpId
+0x9BA3E97F _sce_np_sysutil_cxml_set_npid(cxml::Document&, cxml::Element&, char const*, SceNpId const*)
 0xED136702 cellKeySheapRwmDelete
 0x3F22403E cellUsbPspcmPollResetAsync
-0xED7791B6 _ZN3paf9Framework16GetSoundInstanceEv
-0xBCAACE40 _ZNK3paf4View8PageRootEPv
+0xED7791B6 paf::Framework::GetSoundInstance()
+0xBCAACE40 paf::View::PageRoot(void*) const
 0x4D5D1D07 cellGcmSetAlphaFunc
-0xE2BBDCC8 _ZN8XMWIOCTL13ConnectDeviceEy
+0xE2BBDCC8 XMWIOCTL::ConnectDevice(unsigned long long)
 0x3C413AC6 cellPngEncCoreCreate
 0xC3F08375 sceNpMatching2SetRoomMemberDataInternalVsh
-0xAE8FBFC6 _ZN3vsh7sysutil10SetHandlerEiPKcPFiPKvjE
-0x009207F4 _ZN3paf8PhScroll10WidgetTypeEv
+0xAE8FBFC6 vsh::sysutil::SetHandler(int, char const*, int (*)(void const*, unsigned int))
+0x009207F4 paf::PhScroll::WidgetType()
 0x824433F0 cellVdecEndSeq
 0xCAC9FC34 cellHttpClientSetUserAgent
 0x3DC09A3E cellRtcSetCurrentSecureTick
@@ -6162,36 +6162,36 @@
 0xF819BE91 sceNpTusSetMultiSlotVariableVUser
 0x3140F6E1 cellFsSetIoBuffer
 0x1B6E8CD2 cellSysutilAvcExtSetWindowRotation
-0x3DC0DA39 _ZN3paf5PhWeb8SetFocusEPNS_7PhEventEi
+0x3DC0DA39 paf::PhWeb::SetFocus(paf::PhEvent*, int)
 0x9A0159AF cellGcmGetReportDataAddress
 0x1AC65942 sceAdCacheSpacesPrepare
 0x2683C25D ATEgetRegWordFirst
-0x9D014B62 _ZN3paf8PhCamera5SetupEv
+0x9D014B62 paf::PhCamera::Setup()
 0xB529D259 isalnum
 0x51ECF361 cellSailFutureIsDone
 0xAD049ECF cellMicGetFormatEx
 0xA48E0236 cellNetCtlMintXAddHandler
 0x92D85178 smf_ApPs_GetODInfo
 0x78FD9E05 cellVpost2QueryAttr
-0x546B3D02 _ZN3paf8PhWidget10WidgetTypeEv
-0xE084E017 _ZN3paf5PhWeb5CloseEv
+0x546B3D02 paf::PhWidget::WidgetType()
+0xE084E017 paf::PhWeb::Close()
 0xEBB8E70A cellVdecStartSeqExt
 0xBDB1E067 cellM4vEncOpenEx
 0x99A14141 cellPngEncCoreEncodeData
 0x84D310D3 cellGcmSetCallCommand
 0x3FC3BBB1 ERR_error_string
-0xD59C7D79 _ZN3vsh20MakeErrorcodeMessageERSbIwSt11char_traitsIwESaIwEEj
+0xD59C7D79 vsh::MakeErrorcodeMessage(std::basic_string<wchar_t, std::char_traits<wchar_t>, std::allocator<wchar_t>>&, unsigned int)
 0x150FDCA3 sceNpCommerce2GetContentRatingDescriptor
-0x7A7BCEED _ZN3paf8PhWidget8SetStyleEib
-0x4C229CCA _Z16mat4_from_rotyxzfff
+0x7A7BCEED paf::PhWidget::SetStyle(int, bool)
+0x4C229CCA mat4_from_rotyxz(float, float, float)
 0x2093252B cellSpursQueueGetTasksetAddress
 0x66A23100 cellFontBindRenderer
-0xB60C4316 _ZN3paf9PhHandler11HandlerProcEPNS_7PhEventE
+0xB60C4316 paf::PhHandler::HandlerProc(paf::PhEvent*)
 0xF6ECD42C smvd4CancelDecode
 0x94E9F81D cellGameGetHomeLaunchOptionPath
 0x61405530 FTC_Manager_RemoveFaceID
-0x3D32A7F4 _ZNSt6localeC2EPKci
-0xFEBB5DBB _ZN3paf6PhList13SetVisibleTopEi
+0x3D32A7F4 std::locale::locale(char const*, int)
+0xFEBB5DBB paf::PhList::SetVisibleTop(int)
 0x8CDF8C70 cellGcmGetDefaultSegmentWordSize
 0x5F4B48FA sceNpMatching2GetRoomMemberDataInternalLocalVsh
 0xE6C7D333 cellHttpClientSetMinSslVersion
@@ -6200,9 +6200,9 @@
 0xF7A88701 sceNpC7yLookupNpIdRequestVsh
 0xDD1B59F0 cellMicOpen
 0x58C89C4A cellWebBrowserEstimate
-0xD73321ED _ZNSt10ostrstreamD1Ev
-0x814B3D90 _ZN3paf8PhXmList8FocusOutEf
-0x1CD57819 _ZN3paf10PhMenuList12SetShowStateEii
+0xD73321ED std::ostrstream::~ostrstream()
+0x814B3D90 paf::PhXmList::FocusOut(float)
+0x1CD57819 paf::PhMenuList::SetShowState(int, int)
 0x5AB62AF9 cellUsbdUnregisterCompositeLdd
 0xBBF7354E fegetexceptflag
 0xF0A9182B sceNpFriendlist
@@ -6224,23 +6224,23 @@
 0xDA8E322D sceNpCommerce2GetPrice
 0x40BC33C8 cellSysutilAvcExtSetWindowSize
 0x9117DF20 cellHddGameCheck
-0xEA790023 _ZN3vsh10OptionMenu6IsOpenEv
+0xEA790023 vsh::OptionMenu::IsOpen()
 0x9CB12C89 cellOskDialogExtDisableHalfByteKana
 0x058ADDC8 UTF8toGB18030
 0x0B4F2475 CEULock_destroy
-0x4F99DA2B _ZN3vsh16SetReleaseTargetENS_13ReleaseTargetE
+0x4F99DA2B vsh::SetReleaseTarget(vsh::ReleaseTarget)
 0x8AA5FCD3 cellHttpClientSetTotalPoolSize
 0x60A4DAAB cellWebBrowserConfigSetVersion
 0x33726893 CEUQueue_dequeue
 0xD338A65A cellFsFdatasync
 0xD9B8C0EE cellSysmoduleLoadModuleInternal
-0xF85DD772 _ZN7bXUtilsC1Ev
+0xF85DD772 bXUtils::bXUtils()
 0xE95FFA0A sys_process_wait_for_game_process
 0x17481336 cellSysutilAvc2UnloadAsync
 0xD45C3481 cellPesmInitEntry2
 0xAFE5EBC4 FT_CeilFix
-0x42B2CD4A _ZNK3paf4View10GetTopPageEv
-0x19C901CE _ZTv0_n12_NSt9strstreamD0Ev
+0x42B2CD4A paf::View::GetTopPage() const
+0x19C901CE virtual thunk to std::strstream::~strstream()
 0xAF73A64E cellHttpRequestSetContentLength
 0xB31615FF sceNpGetSdkVersionString
 0x84378DDC wcsncpy
@@ -6249,8 +6249,8 @@
 0x5F922A30 _Dscale
 0x2DF339BC _f_floorf
 0xBD273A88 cellFsStReadGetRegid
-0x174754F0 _ZNK7bXCeDoc8GetChildEP8bXCeNode
-0x1C71A71C _ZN3paf5Sound6Output4StopEPv
+0x174754F0 bXCeDoc::GetChild(bXCeNode*) const
+0x1C71A71C paf::Sound::Output::Stop(void*)
 0x6D045C2E cellUserTraceUnregister
 0x4F4D2E71 FT_Stream_GetLong
 0x002E8DA2 cellDmuxPeekAuEx
@@ -6266,14 +6266,14 @@
 0xFB81426D iswlower
 0xFF34C76C sys_rsxaudio_stop_process
 0xDDC81B5A cellSpursTraceStop
-0xEEFAA794 _ZN3paf14PhCheckBoxList8GetCheckEi
+0xEEFAA794 paf::PhCheckBoxList::GetCheck(int)
 0xC3E611C8 FT_Stream_GetShort
 0xE5E2B09D cellAudioOutGetNumberOfDevice
-0x0648F3BB _ZN3vsh15RaiseFatalErrorEj
+0x0648F3BB vsh::RaiseFatalError(unsigned int)
 0x4826F6D5 sceNpClansDisbandClan
 0xD80B1697 sceNpUpdateClockStart
 0xAEB78725 sys_lwmutex_trylock
-0x6BFD6A5A _ZN3vsh11LayoutTable4SwapEiii
+0x6BFD6A5A vsh::LayoutTable::Swap(int, int, int)
 0xB2748A9F _Freeloc
 0xA4BFAE51 cellJpgEncOpen
 0x9FAA12BE cellVideoOutConfigure2
@@ -6286,7 +6286,7 @@
 0x986EC8D3 cellSsDrvAuthDiscPs3
 0x5D25F866 cellCameraOpenEx
 0x49E714AF sceNetBase64Encoder
-0x31B3E5CC _ZNSs5_TidyEbj
+0x31B3E5CC std::basic_string<char, std::char_traits<char>, std::allocator<char>>::_Tidy(bool, unsigned int)
 0xA4AFEB98 FT_Stroker_BeginSubPath
 0x0F6D0878 cellKbConfigInit
 0xC3A7E8F2 FT_Stroker_ExportBorder
@@ -6302,25 +6302,25 @@
 0x9897FBD1 cellSailPlayerRemoveDescriptor
 0xDDEBD2A5 cellSailAviMovieGetStreamByTypeAndIndex
 0x7C409D1D Zi8GetGlobalDataSize
-0x608ABBB5 _ZNSt13basic_filebufIcSt11char_traitsIcEE5uflowEv
+0x608ABBB5 std::basic_filebuf<char, std::char_traits<char>>::uflow()
 0x97670A90 cellUsbPspcmGetAddr
 0xF244E799 _cellSpursCreateJobQueue
 0xEAC62795 _Cdivcc
-0xFB7731FB _ZN3paf8PhXmItem12ReleaseLabelEi
+0xFB7731FB paf::PhXmItem::ReleaseLabel(int)
 0xE24EEA19 sceNpMatchingGetRoomListLimitGUI
 0x5C06471E cellMouseConfigAssignPortID
-0xE50065BE _ZN3paf10PhItemSpin14SetLayoutStyleEiiif
+0xE50065BE paf::PhItemSpin::SetLayoutStyle(int, int, int, float)
 0x609EC7D5 cellPngDecGetUnknownChunks
 0x6EF6B083 _FCsubcr
-0x2EB5C13A _ZNSt13basic_filebufIcSt11char_traitsIcEE4syncEv
-0x0633EDC2 _ZN8cxmlutil9GetStringERKN4cxml7ElementEPKcPS5_Pj
+0x2EB5C13A std::basic_filebuf<char, std::char_traits<char>>::sync()
+0x0633EDC2 cxmlutil::GetString(cxml::Element const&, char const*, char const**, unsigned int*)
 0xC7BDB7EB cellRtcGetTick
 0x5D543BBE sceNpBasicGetMessageAttachmentEntry
-0xD05EA37C _ZNKSt19istreambuf_iteratorIwSt11char_traitsIwEEdeEv
+0xD05EA37C std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>::operator* () const
 0xD8E7C747 cellGcmSetVertexProgram
 0x3B22E88A isxdigit
 0xC044FAB1 cellSailDescriptorOpen
-0x4D0CAA13 _ZN3paf9PhHandler9IsTimerCBEi
+0x4D0CAA13 paf::PhHandler::IsTimerCB(int)
 0x76ED4243 _Wcsftime
 0x7156446D cellApostSrcInitialize3
 0x418036E3 _FTgamma
@@ -6336,32 +6336,32 @@
 0xBA8C569E sceNpSnsFbGetLongAccessToken
 0x3711833F sceNpSnsFbAbortHandle
 0x9DB622E8 sceNpAuthAbortOAuthRequest
-0xB923666A _ZN3paf9PhNumSpin11UpdateStateEv
+0xB923666A paf::PhNumSpin::UpdateState()
 0xCE618901 _QN4cell5Daisy26LFQueue2CompletePopPointerEPNS0_8LFQueue2EiPFiPvjEj
 0x7E134A90 cellBGDLSetMode
 0x108A87FB sceNetXmppUnregisterExtNotificationHandler
 0x4AC7BAE4 cellSpursEventFlagClear
 0x6545B7DE fgetpos
 0x1672170E sceNpScoreRecordScore
-0xDAE2950C _ZN7bXCeDoc15AddElementChildEP8bXCeNodePcP12bXCeAttrListS2_j
+0xDAE2950C bXCeDoc::AddElementChild(bXCeNode*, char*, bXCeAttrList*, char*, unsigned int)
 0x2F45D39C strlen
-0xEDB089C8 _ZNK3paf11SurfaceBase20GetDevicePixelFormatEv
+0xEDB089C8 paf::SurfaceBase::GetDevicePixelFormat() const
 0x9B1FEAA3 cellSsVtrmEncryptWithPortability
-0x28ACB77F _ZN4cell5Daisy9_snprintfEPcjPKcz
+0x28ACB77F cell::Daisy::_snprintf(char*, unsigned int, char const*, ...)
 0x38954133 cellHttpTransactionGetSslCipherBits
 0xFC7D346E sceNpTusGetMultiSlotVariableVUserAsync
 0xCFD2CA7D cellFsUtilityUmount
-0x8E7A2AED _Z16pafGumMatrixModei
+0x8E7A2AED pafGumMatrixMode(int)
 0xAF985783 sceNpTusDeleteMultiSlotVariable
 0x35506005 cellApostSrcProcessAsync
 0xCCF0AEFF cellSysutilAvc2SetAttribute
-0xA08ABACC _ZN3paf10PhItemSpin8SetStyleEib
-0x691A56E4 _ZN29xMMSMdRelationResolveAccessor17GetMridFromRecordEPvPy
-0x904DBD32 _ZNSt6locale7_LocimpC1Eb
+0xA08ABACC paf::PhItemSpin::SetStyle(int, bool)
+0x691A56E4 xMMSMdRelationResolveAccessor::GetMridFromRecord(void*, unsigned long long*)
+0x904DBD32 std::locale::_Locimp::_Locimp(bool)
 0x816799DD cellUsbPspcmPollData
 0xB5CB2D56 sceNpBasicRecvMessageAttachment
 0x80161336 FTRenderBuf_Reset
-0xCE14748C _ZN3paf9PhHandler18HandleCommandEventEPNS_7PhEventE
+0xCE14748C paf::PhHandler::HandleCommandEvent(paf::PhEvent*)
 0x629BA0C0 cellOvisInvalidateOverlappedSegments
 0x24802244 iswcntrl
 0x41CCF033 ToEucJpKata
@@ -6370,9 +6370,9 @@
 0xB4FE75E1 cellPngDecGetpCAL
 0xA650DF19 toupper
 0x952269C9 cellSailPlayerGetParameter
-0xFC23139F _ZN3paf5Sound6Output9ConfigureEjP29xSettingAudioOutConfigurationP22xSettingAudioOutOptionj
+0xFC23139F paf::Sound::Output::Configure(unsigned int, xSettingAudioOutConfiguration*, xSettingAudioOutOption*, unsigned int)
 0x08269F37 cellSysutilAvcGetShowStatus
-0xCEF919B4 _ZNK3paf5PhWeb9UISession16getDefaultStringEv
+0xCEF919B4 paf::PhWeb::UISession::getDefaultString() const
 0x61C2F19F sceNetUpnpTerm
 0xE847341F sceNpTusSetDataAsync
 0x46BCC9FF cellHttpClientGetPerHostKeepAliveMax
@@ -6382,7 +6382,7 @@
 0x507363CB cellVideoPlayerOpenContentId
 0xE84D6197 sqlite3_column_int64
 0xC4CCCD1F modff4
-0x7531D5C0 _ZN3paf6PhList10SetItemNumEi
+0x7531D5C0 paf::PhList::SetItemNum(int)
 0x1E969735 gnpc_resp_get_count
 0xA719DFA3 cellGcmSetClearColor
 0x64AAF016 raw_spu_read_ldouble
@@ -6394,34 +6394,34 @@
 0x445C878F cellFsSdataOpenWithVersion
 0x0C9B8305 hypotf4
 0xEA2E9FFC sceNpLookupCreateTransactionCtx
-0xB7DFCE90 _ZN3paf6PhText10WidgetTypeEv
+0xB7DFCE90 paf::PhText::WidgetType()
 0xEC29CAB1 mvcDecQueryCharacteristics
 0xB0A1F8C6 cellGameContentErrorDialog
-0xEF6F90D8 _ZNKSt5ctypeIwE11do_scan_notEsPKwS2_
+0xEF6F90D8 std::ctype<wchar_t>::do_scan_not(short, wchar_t const*, wchar_t const*) const
 0x98DB2F48 FT_Free
 0xD08B68DA FTCacheStream_CacheEnd
-0xCACDFB2D _ZN3paf13PhAppearPlane10SetTextureERKNS_12SurfaceRCPtrINS_7SurfaceEEEi
+0xCACDFB2D paf::PhAppearPlane::SetTexture(paf::SurfaceRCPtr<paf::Surface> const&, int)
 0x9851F805 sceNpScoreTerm
 0x7E639D78 _QN4cell5Daisy22ScatterGatherInterlockD2Ev
 0xDBBE4790 cellGcmCgGetVertexAttribInputMask
 0xF61609D6 cellPamfReaderGetPresentationEndTime
 0xA0517CDA cellAsfParser2SkipFrameData
-0x4BDA379A _ZNSt8ios_base4InitC1Ev
+0x4BDA379A std::ios_base::Init::Init()
 0xC353353A sys_dbg_initialize_ppu_exception_handler
-0x816AEBC3 _ZNSt9bad_allocD0Ev
-0x5ED4FB7A _ZTv0_n12_NSt13basic_istreamIwSt11char_traitsIwEED0Ev
+0x816AEBC3 std::bad_alloc::~bad_alloc()
+0x5ED4FB7A virtual thunk to std::basic_istream<wchar_t, std::char_traits<wchar_t>>::~basic_istream()
 0x250E633D sceNpC7yScoreRecordScoreResultVsh
 0x216FCD2A _Atrealloc
-0xA709A39E _ZN3paf7PhMicon11SetChannelsEi
+0xA709A39E paf::PhMicon::SetChannels(int)
 0x5E2EE0F0 cellGcmGetDefaultCommandWordSize
 0x844C7E10 cellFt2dDestroy
-0xC11E4924 _ZN3paf13PhApplication13GetRootScreenEv
+0xC11E4924 paf::PhApplication::GetRootScreen()
 0x938FB946 _tanf4fast
 0x5F2D9257 sceNpLookupInit
 0x40E0FF25 _WGenld
 0xDEF86A83 isxdigit_ascii
 0xB9944334 cellAsfParser2AStdGetStreamObjectInfo
-0xEEE37C22 _ZN3paf7PhSPrim8SetStyleEii
+0xEEE37C22 paf::PhSPrim::SetStyle(int, int)
 0xB1C02D66 sceNpCommerceGetCurrencyInfo
 0xACE90BE4 _Dtentox
 0x03A2F42A sceNpMatching2RegisterLobbyMessageCallback
@@ -6431,14 +6431,14 @@
 0x9A81E583 fmodf
 0xDF6F03FC avcDecQueryMemory
 0x57415DD3 cellSailFeederVideoInitialize
-0x5BB83612 _ZN10psjsvectorC1EjPfPNS_12ELEMENT_TYPEE
-0x8C3DEAC5 _ZN3paf7PhMicon10WidgetTypeEv
-0xCD374B29 _ZN12bXCeAttrList7DestroyEv
+0x5BB83612 psjsvector::psjsvector(unsigned int, float*, psjsvector::ELEMENT_TYPE*)
+0x8C3DEAC5 paf::PhMicon::WidgetType()
+0xCD374B29 bXCeAttrList::Destroy()
 0x6C6285C6 acoshf
 0x6773950B atxenc_set_config_data
-0x8F1E4506 _ZN11PSJSContext11SetUserDataEPv
+0x8F1E4506 PSJSContext::SetUserData(void*)
 0x50DD56FD smf_ApPs_GetTransformationMatrix
-0x9E51FD20 _Z9xcbGetMMSPv
+0x9E51FD20 xcbGetMMS(void*)
 0x5980A293 cellHttpClientGetAutoAuthentication
 0xC68B81BF avcDecClose
 0x58AA86CD cellAvcEncQueryResource
@@ -6447,26 +6447,26 @@
 0x4323CDA7 _sys_net_lib_sysctl
 0xC76C2DAF sceNpAacDestroyRequest
 0xACCA2F83 copysignf
-0xB9152E15 _ZNK3paf6Module12GetInterfaceEi
-0x9F143A8C _ZN3paf6PhList6RedrawEv
+0xB9152E15 paf::Module::GetInterface(int) const
+0x9F143A8C paf::PhList::Redraw()
 0x5F81900C sys_config_unregister_service
 0x1B985476 sceNpAacRequestSetCredentials
 0x35168520 _sys_heap_malloc
 0xB1A33DEA FT_Stream_ReadLongLE
 0x660ECC35 xSettingPhotoGetInterface
-0x2EE83DE4 _ZNK7bXCeDoc12GetAttributeEPK8bXCeNodePKc
-0x23EF7642 _ZNKSt7num_getIcSt19istreambuf_iteratorIcSt11char_traitsIcEEE8_GetifldEPcRS3_S6_NSt5_IosbIiE9_FmtflagsERKSt6locale
+0x2EE83DE4 bXCeDoc::GetAttribute(bXCeNode const*, char const*) const
+0x23EF7642 std::num_get<char, std::istreambuf_iterator<char, std::char_traits<char>>>::_Getifld(char*, std::istreambuf_iterator<char, std::char_traits<char>>&, std::istreambuf_iterator<char, std::char_traits<char>>&, std::_Iosb<int>::_Fmtflags, std::locale const&) const
 0x117CD726 cellPngEncClose
 0x03C1A02F sceAdGetSpaceMetadata
 0x24A1EA07 sys_ppu_thread_create
 0x38F364B0 sceNpTusGetDataVUserAsync
-0xE36C18F5 _ZN3paf10PhPlaneDiv10WidgetTypeEv
+0xE36C18F5 paf::PhPlaneDiv::WidgetType()
 0x7E063BBC cellCameraIsAttached
-0x3F10A8D7 _ZNK3paf6PhText13GetTextLengthEv
+0x3F10A8D7 paf::PhText::GetTextLength() const
 0x4D9B75D5 cellPadEnd
 0xE836E451 cellSsUmGetCacheOfProductMode
 0x3E919CBA scalbnf
-0xD5C5EE3D _ZNKSt7num_getIcSt19istreambuf_iteratorIcSt11char_traitsIcEEE6do_getES3_S3_RSt8ios_baseRNSt5_IosbIiE8_IostateERj
+0xD5C5EE3D std::num_get<char, std::istreambuf_iterator<char, std::char_traits<char>>>::do_get(std::istreambuf_iterator<char, std::char_traits<char>>, std::istreambuf_iterator<char, std::char_traits<char>>, std::ios_base&, std::_Iosb<int>::_Iostate&, unsigned int&) const
 0xFC526B72 cellSpursJobQueuePort2PushSync
 0xA6EC00F4 FT_Add_Module
 0x42B23552 sys_prx_register_library
@@ -6483,18 +6483,18 @@
 0xFA7F693D _sys_vprintf
 0xCE4374F6 cellGamePatchCheck
 0xD42475CF cellMarlinDRMcencGetCID
-0x37A6B2F6 _ZN3paf9PhNumSpin8SetStyleEiiRK4vec4
+0x37A6B2F6 paf::PhNumSpin::SetStyle(int, int, vec4 const&)
 0x3A37E7F1 cellSysutilAvc2DestroyWindow
 0x3D549F2A ctanhl
 0x57EA9D70 sjvtdInitialize
-0x4CDAB0BA _ZNSt7_MpunctIwED0Ev
-0x144999C9 _Z15xcbReferDirPathPvPPKcPi
+0x4CDAB0BA std::_Mpunct<wchar_t>::~_Mpunct()
+0x144999C9 xcbReferDirPath(void*, char const**, int*)
 0x76B1A425 cellSailDescriptorSetAutoSelection
 0xBFF6E8D3 cellSailFeederVideoNotifySessionEnd
-0xE3C1B660 _ZN3paf7PhSPrimC1ERNS_9PhSRenderE
+0xE3C1B660 paf::PhSPrim::PhSPrim(paf::PhSRender&)
 0xF7681B9A UTF8stoUTF16s
 0x226CD693 cellFsLsnUnlock
-0x31A81476 _ZdlPvj
+0x31A81476 operator delete(void*, unsigned int)
 0x78DA9B96 sceNpMatchingGetLobbyListVsh
 0x4737F7FE cellM4vEncOpen
 0x529AFC47 FTFaceH_SetRenderScalePoint
@@ -6507,23 +6507,23 @@
 0xC41C6E5D _Scanf
 0x410D42BE sceNpCommerce2DoDlListFinishAsync
 0xE35D54E3 cellSsAimIsDEHXB2
-0x75D9466C _ZN3paf4Cond6NotifyEv
-0x1738DDE3 _Z5lerp3RK4vec4S1_f
+0x75D9466C paf::Cond::Notify()
+0x1738DDE3 lerp3(vec4 const&, vec4 const&, float)
 0x33EE813D scePS2Icon_Setup
 0x0417988E cellCryptoPuUmpn2Char
 0x44980EBF Zi8SetLatinSearchOrder
 0x456DC4AA cellCameraStart
 0xF1AAA2F8 conj
-0x176E3BC4 _ZN3paf10PhCheckBoxC1EPNS_8PhWidgetEPNS_8PhAppearE
-0x6A76DCEE _ZN3paf7PhXmBar7SetFadeEfff
+0x176E3BC4 paf::PhCheckBox::PhCheckBox(paf::PhWidget*, paf::PhAppear*)
+0x6A76DCEE paf::PhXmBar::SetFade(float, float, float)
 0xE5D2293F _Force_raise
-0xF001A741 _ZNSt12strstreambufD1Ev
+0xF001A741 std::strstreambuf::~strstreambuf()
 0x9CF7908C cellGcmSetBackStencilFunc
-0xDAF3996F _ZNSt6locale6globalERKS_
+0xDAF3996F std::locale::global(std::locale const&)
 0x64C305D6 pafGuCgPushShader
-0xB8836B50 _ZNSt9exception18_Set_raise_handlerEPFvRKS_E
+0xB8836B50 std::exception::_Set_raise_handler(void (*)(std::exception const&))
 0xA36EB2C4 cellGcmSetStencilMask
-0x5D711BEE _ZN3paf8PhXmList17SetFocusItemAlphaEfff
+0x5D711BEE paf::PhXmList::SetFocusItemAlpha(float, float, float)
 0xAB1E7527 FT_Stream_Pos
 0x7048A9BA cellSaveDataUserListDelete
 0x5516D621 acosl
@@ -6533,7 +6533,7 @@
 0x7EA2C657 FT_Set_Transform
 0x7EBECBE0 cellGcmSetTransferScaleSwizzle
 0x6C1082AA cellWebBrowserConfigWithVer
-0x4FF7B8A9 _ZN3paf8PhXmList10WidgetTypeEv
+0x4FF7B8A9 paf::PhXmList::WidgetType()
 0x7C5BDE1C UHCtoEUCKR
 0x36F59828 FT_Get_Track_Kerning
 0xC982A84A cellVdecQueryAttrEx
@@ -6547,14 +6547,14 @@
 0x00E2D84B avcDecQueryCharacteristics
 0xDBF300CA sceNpClansJoinClan
 0xA11BA28B FT_New_Library
-0xBC5AD91C _ZNKSt7collateIwE10do_compareEPKwS2_S2_S2_
+0xBC5AD91C std::collate<wchar_t>::do_compare(wchar_t const*, wchar_t const*, wchar_t const*, wchar_t const*) const
 0xA963619C isEucJpKigou
 0xFFE3C63B sceNpUtilXmlEscape
 0xB499D895 FT_Glyph_To_Bitmap
 0x895C604C cellHttpTransactionGetSslCipherName
-0x0DC5F8AB _ZN3paf5PhWeb22SetTargetBlankCallbackEPFvPS0_PKwE
-0xF9FF46A1 _ZNSt13basic_filebufIwSt11char_traitsIwEE7seekoffElNSt5_IosbIiE8_SeekdirENS4_9_OpenmodeE
-0xA67BA4C5 _Z9PSJS_ExecRK11PSJSContextP9PSJSValue
+0x0DC5F8AB paf::PhWeb::SetTargetBlankCallback(void (*)(paf::PhWeb*, wchar_t const*))
+0xF9FF46A1 std::basic_filebuf<wchar_t, std::char_traits<wchar_t>>::seekoff(long, std::_Iosb<int>::_Seekdir, std::_Iosb<int>::_Openmode)
+0xA67BA4C5 PSJS_Exec(PSJSContext const&, PSJSValue*)
 0x34DD6650 _Getcloc
 0xF81ECA25 cellMsgDialogOpen
 0xE840F449 cellUsbPspcmWaitResetAsync
@@ -6569,88 +6569,88 @@
 0xA4E5F5E2 smvd4GetSideInfoPic
 0xCA517C10 cellGcmSetUserClipPlaneControl
 0xC2E2F30D cellSailFeederAudioNotifyCallCompleted
-0x29C739F4 _ZNK3paf7PhSPrim8GetStyleEiR4mat4
+0x29C739F4 paf::PhSPrim::GetStyle(int, mat4&) const
 0x7BDADB01 sys_dbg_get_lwcond_information
 0x498A5036 raw_spu_write_mem
 0x24EA6474 cellDmuxReleaseAu
 0xC8C508DE canonPrintContinue
-0xCB4F4211 _Z30xcbGetSourceStorageMediaRecordPvPS_
+0xCB4F4211 xcbGetSourceStorageMediaRecord(void*, void**)
 0xFB5DB080 _sys_memcmp
 0x98CE061C cellHttpClientGetMinSslVersion
 0x65BF9EA3 cellAudioInGetAvailableDeviceInfo
 0x01036193 cellFiberPpuContextReturnToThread
 0x41C145DC pafGuDrawArray
 0x53D03CE1 sceNpSnsFbCheckThrottle
-0x47AAB531 _ZNSt7_MpunctIcED0Ev
+0x47AAB531 std::_Mpunct<char>::~_Mpunct()
 0x396EA886 smf_ApPs_GetSoundSampleDes2
 0x93CED48D cellWebBrowserShutdown
 0x4EF182DD cellUsbPspcmResetAsync
 0x2E162A62 sceNpTusDestroyTitleCtx
 0xA53D12AE cellGcmSetDisplayBuffer
-0x7907768A _ZNK4cxml8Document14GetHeaderMagicEPc
+0x7907768A cxml::Document::GetHeaderMagic(char*) const
 0x1B50979C cellGcmTransferScaleSurface
 0xE5E0572A cellSailFeederVideoNotifyFrameOut
 0x9EE9F97E sceNpLookupTitleStorage
-0x880E3977 _ZNK3paf9ImageAttr11GetMemWidthEi
+0x880E3977 paf::ImageAttr::GetMemWidth(int) const
 0x29C846C4 cellMtpEnd
-0x44E93267 _ZN3paf8PhXmItem11PlayerStartEffRK4vec4
+0x44E93267 paf::PhXmItem::PlayerStart(float, float, vec4 const&)
 0xB1991509 cellSailComposerGetEsVideoParameter
-0x1B9B3B5C _ZNSt8time_getIcSt19istreambuf_iteratorIcSt11char_traitsIcEEED0Ev
-0x6C0A8512 _ZN4xMMS17DeleteMetadataSetEjPy
+0x1B9B3B5C std::time_get<char, std::istreambuf_iterator<char, std::char_traits<char>>>::~time_get()
+0x6C0A8512 xMMS::DeleteMetadataSet(unsigned int, unsigned long long*)
 0xCA4C4600 cellSpursFinalize
 0xF7D2C560 SSL_CTX_set_info_cb
-0x21DEB478 _ZN3paf5Sound6Output6EnableEb
+0x21DEB478 paf::Sound::Output::Enable(bool)
 0x5F77E8DF cellSailRendererVideoNotifyFrameDone
-0x52330FBD _ZNSt13runtime_errorD0Ev
+0x52330FBD std::runtime_error::~runtime_error()
 0xE92F3FB8 _f_fmaf
 0xDAFE04B9 InputDevice_Ps3Pad_EnableAnalog
-0x868531A3 _ZdaPvj
+0x868531A3 operator delete[](void*, unsigned int)
 0x82B93B60 sceNpMatching2ContextStopVsh
 0x1FA5C87D sceNpTusAddAndGetVariableAsync
-0xFADF8AFF _ZN4rectC1Effff
+0xFADF8AFF rect::rect(float, float, float, float)
 0x56DFE179 cellAudioSetPortLevel
 0x71E5AF7E sceNpLookupSetTimeout
 0x296A46CF cellHttpClientSetPipeline
 0xD86ACB12 cellAtracMultiDecode
 0x34552FA6 cellSpursTaskExitCodeInitialize
-0xDEF981C4 _ZN3paf8PhXmList7FocusInEf
-0x29C11F46 _ZNKSt7codecvtIccSt9_MbstatetE9do_lengthERKS0_PKcS5_j
+0xDEF981C4 paf::PhXmList::FocusIn(float)
+0x29C11F46 std::codecvt<char, char, std::_Mbstatet>::do_length(std::_Mbstatet const&, char const*, char const*, unsigned int) const
 0xFA0C2DE0 cellFontFTGetInitializedRevisionFlags
 0xD7471088 cellHttpClientSetConnTimeout
-0x9C778A46 _ZNK3paf9PhSRender8GetStyleEiRi
-0x425277FA _ZN3vsh13MessageDialog10SetBgAlphaEf
+0x9C778A46 paf::PhSRender::GetStyle(int, int&) const
+0x425277FA vsh::MessageDialog::SetBgAlpha(float)
 0xE7086F05 cellRtcGetWin32FileTime
 0x7240C64D sceNpTssGetDataNoLimitAsync
 0xAA1E687D isgraph
-0x4E9C5713 _ZNK3paf7PhMicon7GetCropEv
-0xCB1D791D _ZN8XMWIOCTL19StorageDriverAccessEjPvyS0_yPy
+0x4E9C5713 paf::PhMicon::GetCrop() const
+0xCB1D791D XMWIOCTL::StorageDriverAccess(unsigned int, void*, unsigned long long, void*, unsigned long long, unsigned long long*)
 0xFBEA0DCD cellGcmSetFragmentProgramLoad
 0x37AAD85F cellSailRecorderDumpImage
-0xD275ADBD _Z16x3USBMass_Formatyib
+0xD275ADBD x3USBMass_Format(unsigned long long, int, bool)
 0x865ACF74 cellPrintStartPage
 0x05FA21EB sceNpAacStartRequest
 0xE1858899 _Getpwctrtab
 0x91C274F8 canonPrintStartPage
-0x7692C9C7 _ZN3paf7PhModel14SetFrameRepeatEi
-0x47E5C318 _ZNSt8_LocinfoD2Ev
+0x7692C9C7 paf::PhModel::SetFrameRepeat(int)
+0x47E5C318 std::_Locinfo::~_Locinfo()
 0x9E9005D5 mios2_Client_SharedMemoryMap
 0x90B27880 strtoumax
 0xF2A1D63F CEUQueue_remove
-0xEC70F53F _ZN3paf9PhNumSpin14SetLayoutStyleEiiif
-0x9DF5AAD4 _ZN3paf8PhWidget14SetLayoutStyleEiiii4vec4
+0xEC70F53F paf::PhNumSpin::SetLayoutStyle(int, int, int, float)
+0x9DF5AAD4 paf::PhWidget::SetLayoutStyle(int, int, int, int, vec4)
 0x90EF2963 cellPngEncWaitForOutput
-0xC6E09225 _ZNSt13basic_filebufIwSt11char_traitsIwEE5_InitEPSt6_FiletNS2_7_InitflE
+0xC6E09225 std::basic_filebuf<wchar_t, std::char_traits<wchar_t>>::_Init(std::_Filet*, std::basic_filebuf<wchar_t, std::char_traits<wchar_t>>::_Initfl)
 0xDB14B37B sys_dbg_set_address_to_dabr
 0xB5D353E8 _LDtentox
 0x918288FB cellStorageDataImport
-0xC1CA854A _ZN3paf10PhSaveData12SetFrameLoopEff
+0xC1CA854A paf::PhSaveData::SetFrameLoop(float, float)
 0x27DEDA93 sceNpTrophySetSoundLevel
-0x1A4F2FA6 _ZNSt8ios_base7failureD0Ev
+0x1A4F2FA6 std::ios_base::failure::~failure()
 0x41251F74 sceNp2Init
-0x63A2B2CC _ZNKSt8messagesIcE8do_closeEi
+0x63A2B2CC std::messages<char>::do_close(int) const
 0x6F867071 cellSailComposerReleaseEsVideoAu
 0x45FE2FCE _sys_spu_printf_initialize
-0xCF23DE13 _Z14xcbNotifyErrorPv7xResultS_PKcS2_S2_
+0xCF23DE13 xcbNotifyError(void*, xResult, void*, char const*, char const*, char const*)
 0xA8E94A19 svc1dSetPictureSize
 0x9B4E3A74 cellJpgEncWaitForOutput
 0x9119CFD1 cellAtracMultiResetPlayPosition
@@ -6658,20 +6658,20 @@
 0x945A7661 scePS2OSD_TitleWordWrapGB18030
 0xFDCC4831 cellAvcEncGetAuInfo
 0x2D52848B cellHttpTransactionAbortConnection
-0x5E55AB8C _ZSt10_GetloctxtIwSt19istreambuf_iteratorIwSt11char_traitsIwEEEiRT0_S5_jPKT_
+0x5E55AB8C int std::_Getloctxt<wchar_t, std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>>(std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>&, std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>&, unsigned int, wchar_t const*)
 0xBDB10C87 cellGcmGetCurrentBuffer
 0x726B8588 npTrophyUtilDestroyCtx
-0xBD069EC5 _ZN9PSJSValuedaEPv
+0xBD069EC5 PSJSValue::operator delete[](void*)
 0x5F68C268 cellRtcSetWin32FileTime
-0xE6547E35 _ZNSt8messagesIwED0Ev
+0xE6547E35 std::messages<wchar_t>::~messages()
 0x243B52D8 _Mbtowcx
 0x1EA00DA8 SSL_CIPHER_get_name
 0x3C95AA78 _sys_net_lib_sync_signal
 0x3CADDF6C cellUsbPspcmWaitSendAsync
-0xF64B7CD4 _ZN9PSJSValuenaEj
-0x1BBCB5B9 _ZN4cell5Daisy26LFQueue2CompletePopPointerEPNS0_8LFQueue2EiPFiPvjEj
-0x7AC4128A _ZN7bXCeDoc14CreateTextNodeEPcj
-0x3933645F _ZNKSt7_MpunctIwE14do_frac_digitsEv
+0xF64B7CD4 PSJSValue::operator new[](unsigned int)
+0x1BBCB5B9 cell::Daisy::LFQueue2CompletePopPointer(cell::Daisy::LFQueue2*, int, int (*)(void*, unsigned int), unsigned int)
+0x7AC4128A bXCeDoc::CreateTextNode(char*, unsigned int)
+0x3933645F std::_Mpunct<wchar_t>::do_frac_digits() const
 0x5E849303 sceNpBasicSetPresenceDetails2
 0x323DEB41 cellMicSetSignalAttr
 0xFE23DBE9 _log2f4
@@ -6679,7 +6679,7 @@
 0x07F400E3 _LCbuild
 0xFC9EB3A3 _cellAudioPathThruSpdifGetInfo
 0xEE14B155 cellAvsetResistEventCallback
-0x6B57CB4D _ZN3paf14PhCheckBoxList8SetCheckEibb
+0x6B57CB4D paf::PhCheckBoxList::SetCheck(int, bool, bool)
 0x5F909B17 _cellGcmFunc1
 0x800E24A1 cellGcmSetTransformBranchBits
 0x00367BE0 fminl
@@ -6692,10 +6692,10 @@
 0x6DCE048C cellGemConvertVideoStart
 0x186E96BC SSL_set_bio
 0x12D0B0F9 sceNpMatching2ContextStart
-0x706FEED9 _ZN4cell5Daisy4Lock8pushOpenEv
+0x706FEED9 cell::Daisy::Lock::pushOpen()
 0xCE91FF18 nanf
 0xBF97B657 FT_New_Memory
-0xF35FE0BC _ZN3paf8PhXmList11SetTopAlphaEfff
+0xF35FE0BC paf::PhXmList::SetTopAlpha(float, float, float)
 0x1E85EF02 f_atanf
 0x6C62D879 UTF32toUCS2
 0x9FE3DDE6 FT_GlyphLoader_Reset
@@ -6704,23 +6704,23 @@
 0x32689828 ARIBstoUTF8s
 0xAED08DB1 FT_Has_PS_Glyph_Names
 0x68D671F4 sceNpGetStatus
-0x87790DD7 _ZN3paf7PhModel8SetModelEPvi
+0x87790DD7 paf::PhModel::SetModel(void*, int)
 0x10A06011 sceNetXmppRemoveMessageFromServer
 0x368D1690 cellGcmSetVertexTextureAddress
-0xE9BEE64D _ZN4xMMS20GetMridFromDirectoryEPhS0_Py
-0x4299A92C _Z40_sce_np_sysutil_recv_packet_fixedmem_subiPN16sysutil_cxmlutil11FixedMemoryERN4cxml8DocumentERNS2_7ElementE
+0xE9BEE64D xMMS::GetMridFromDirectory(unsigned char*, unsigned char*, unsigned long long*)
+0x4299A92C _sce_np_sysutil_recv_packet_fixedmem_sub(int, sysutil_cxmlutil::FixedMemory*, cxml::Document&, cxml::Element&)
 0x182CD542 tgammal
 0x96D1B95E log2f4fast
 0xED4A0148 cellPhotoExportFinalize
-0x2CD62587 _ZN4cxml8Document14SetHeaderMagicEPKc
+0x2CD62587 cxml::Document::SetHeaderMagic(char const*)
 0x7EB292CD cellOskDialogExtSetBaseColor
-0xFDD01957 _ZN3paf6PhSpin11SetSelectedEi
+0xFDD01957 paf::PhSpin::SetSelected(int)
 0x947AE18E _LHypot
 0x9EA2D869 sceNpC7yLookupNpIdResultVsh
-0x2C241D13 _ZnajjRKSt9nothrow_t
+0x2C241D13 operator new[](unsigned int, unsigned int, std::nothrow_t const&)
 0x1B6F5F4D sceAdFlushReports
 0x6144F033 cellWebComponentCreateAsync
-0x0241B884 _ZN3paf8PhWidget7SetTextERKSbIwSt11char_traitsIwESaIwEEi
+0x0241B884 paf::PhWidget::SetText(std::basic_string<wchar_t, std::char_traits<wchar_t>, std::allocator<wchar_t>> const&, int)
 0xD8F79F4C log10
 0x969403F9 cellGcmSetTransferDataFormat
 0x7FB3C6A5 cellWebBrowserConfig2
@@ -6728,45 +6728,45 @@
 0x80D678BC sceNpMatching2RegisterSignalingCallbackVsh
 0xA9F5B75C cellSysutilAvc2GetSpeakerMuting
 0xFD81F6CA _Stoflt
-0xBF575328 _ZNK3paf9PhSRender8GetStyleEiR4mat4
+0xBF575328 paf::PhSRender::GetStyle(int, mat4&) const
 0xDA0FB37E FTFaceH_FontStyleName
 0x398483AA _expm1f4fast
-0x4B1AD744 _ZdaPvjRKSt9nothrow_t
+0x4B1AD744 operator delete[](void*, unsigned int, std::nothrow_t const&)
 0x9BE42C17 cellFsUtilityEraseHddDataWithCallback
 0x72C2D9F7 msmw_LockDestroy
 0xDA43F526 cellAtracMultiSetLoopNum
 0x54876603 cellSpursQueueSize
 0x4B77752F cellVideoPlayerInitialize
-0xEB66C2F7 _ZN13PSJSValueImpl6DecRefEv
+0xEB66C2F7 PSJSValueImpl::DecRef()
 0x332A74DD cellRtcTickAddYears
 0xD277E345 sceSystemFileGetValuePtr
-0x7F155BBA _ZN3paf10PhSaveData18SetCurrentLightingEii
+0x7F155BBA paf::PhSaveData::SetCurrentLighting(int, int)
 0x01E3CDE3 CEComGetClassObject
 0x840C5239 cellSpursJobQueueGetHandleCount
 0x551BEDA8 CEULock_release
 0xA5F629E4 cellCryptoPuRsavp1512
 0x191AD326 pafGuViewport
-0x384F93FC _ZN3paf8PhWidget13UpdatePrepareEv
+0x384F93FC paf::PhWidget::UpdatePrepare()
 0x96E6303B _WStoxflt
-0x26F90ED8 _ZN8psjsnameC1ERK11PSJSContextPKti
+0x26F90ED8 psjsname::psjsname(PSJSContext const&, unsigned short const*, int)
 0xF0B47A17 SSLCERT_NAME_oneline
 0x6FFDE2CB FTRenderSurface_Init
 0x4DB8DD87 inflateEnd
 0xD737FD2D sceNpLookupWaitAsync
-0xF56E1FBD _ZN3paf7PhModelC1EPNS_8PhWidgetEPNS_8PhAppearE
-0x84D7A733 _ZN3paf10MessageBox25SetMessageBoxSoundHandlerEPFvNS0_9SoundTypeEE
+0xF56E1FBD paf::PhModel::PhModel(paf::PhWidget*, paf::PhAppear*)
+0x84D7A733 paf::MessageBox::SetMessageBoxSoundHandler(void (*)(paf::MessageBox::SoundType))
 0x882689F2 _Makeloc
-0x10DEDCC7 _ZN3paf7PhPlane10WidgetTypeEv
+0x10DEDCC7 paf::PhPlane::WidgetType()
 0x079F0E87 sceNpTrophyGetGameProgress
 0x52BB9416 smvd2GetVersionNumber
 0x189A74DA cellSysutilCheckCallback
-0xB0E7C2F3 _ZNSiD0Ev
-0x23A87483 _ZNKSt8time_getIwSt19istreambuf_iteratorIwSt11char_traitsIwEEE11do_get_timeES3_S3_RSt8ios_baseRNSt5_IosbIiE8_IostateEPSt2tm
+0xB0E7C2F3 std::basic_istream<char, std::char_traits<char>>::~basic_istream()
+0x23A87483 std::time_get<wchar_t, std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>>::do_get_time(std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>, std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>, std::ios_base&, std::_Iosb<int>::_Iostate&, std::tm*) const
 0x431A1DCA _SceAdecCorrectPtsValue_M4Aac
 0xC757C2AA cellVdecStartSeq
-0xCCA3B0D5 _Z19xcbGetOperationTypePvP25_xCB_ContentOperationType
-0x4D31F663 _ZN12bXCeAttrList12GetAttributeEi
-0x1FA740DB _Z33_sce_np_sysutil_send_empty_packetiPN16sysutil_cxmlutil11FixedMemoryEPKcS3_
+0xCCA3B0D5 xcbGetOperationType(void*, _xCB_ContentOperationType*)
+0x4D31F663 bXCeAttrList::GetAttribute(int)
+0x1FA740DB _sce_np_sysutil_send_empty_packet(int, sysutil_cxmlutil::FixedMemory*, char const*, char const*)
 0xEDA4250D sceNpC7yTusFreeTransactionResourceVsh
 0x683CACB3 sinh
 0xE4046AFE cellAudioGetPortBlockTag
@@ -6774,10 +6774,10 @@
 0x972AB46C sceNpCommerce2GetContentInfo
 0xF930CC21 sceAdConnectContext
 0x0B8D63AE cellSysutilPacketEnd
-0xD1E1C04D _ZN3paf7PhMicon4PlayEv
+0xD1E1C04D paf::PhMicon::Play()
 0xB7B4ECEE cellSailRendererAudioNotifyCallCompleted
 0xDB69D144 cellCryptoPuChar2Umpn
-0x1527FE95 _ZNSt15basic_streambufIwSt11char_traitsIwEE4syncEv
+0x1527FE95 std::basic_streambuf<wchar_t, std::char_traits<wchar_t>>::sync()
 0x0A10C8D1 cellAvcEncOpenEx
 0x9F951810 cellFsAioFinish
 0x32267A31 cellSysmoduleLoadModule
@@ -6785,25 +6785,25 @@
 0x5BA98E47 cellSysutilAvcExtStopVoiceDetection
 0x13671514 cellSpursJobQueueSetWaitingMode
 0x34A81091 cellFiberPpuContextSelf
-0xC53AB1C0 _ZNSt8numpunctIwE5_InitERKSt8_Locinfo
+0xC53AB1C0 std::numpunct<wchar_t>::_Init(std::_Locinfo const&)
 0xD41D3BD2 cellRtcTickAddHours
 0x2406F7D7 cellTiffDecExtSetParameter
-0x02393512 _ZN4xMMS12DestroyQueryEPv
+0x02393512 xMMS::DestroyQuery(void*)
 0x5C306D39 cellAvsetSetAudioMute
 0xC4100412 sceNpMatchingCancelRequestGUI
 0x073B89D5 cellSysutilAvcGetSpeakerVolumeLevel
-0x18320785 _ZN4vec23setEff
-0xD1CDDADD _ZN3paf8PhWidget11UpdateStateEv
+0x18320785 vec2::set(float, float)
+0xD1CDDADD paf::PhWidget::UpdateState()
 0xB6AAB704 FT_List_Remove
 0xC7AFC42A sceNpCommerce2DoServiceListStartAsync
 0x01B0CBF4 l10n_convert
-0x2D8BE7E8 _ZNKSt9exception6_RaiseEv
-0xAB211D97 _ZNKSt7num_putIcSt19ostreambuf_iteratorIcSt11char_traitsIcEEE6do_putES3_RSt8ios_basecb
+0x2D8BE7E8 std::exception::_Raise() const
+0xAB211D97 std::num_put<char, std::ostreambuf_iterator<char, std::char_traits<char>>>::do_put(std::ostreambuf_iterator<char, std::char_traits<char>>, std::ios_base&, char, bool) const
 0x025CE169 cellSearchGetMusicSelectionContext
-0xDC4D7540 _ZNSt5ctypeIwED1Ev
-0x4B00C738 _ZN3paf13AVCopyControl11SetVBIDCodeEjj
+0xDC4D7540 std::ctype<wchar_t>::~ctype()
+0x4B00C738 paf::AVCopyControl::SetVBIDCode(unsigned int, unsigned int)
 0x7B9CBB74 cellSpursTraceFinalize
-0xDC981B5F _ZNSt13basic_filebufIcSt11char_traitsIcEE9underflowEv
+0xDC981B5F std::basic_filebuf<char, std::char_traits<char>>::underflow()
 0x81FE030C cellCelpEncEncodeFrame
 0xA797790F wcsstr
 0x24054920 sceNpAacAbortRequest
@@ -6813,7 +6813,7 @@
 0x7C370679 _Foprep
 0xFEFBE065 _Stderr
 0x1986F2CD cellImeJpGetPredictList
-0x161E2246 _ZNK3paf11PhLabelText12GetMaxHeightEv
+0x161E2246 paf::PhLabelText::GetMaxHeight() const
 0x9A62982A _sys_net_lib_sync_wait
 0xE6C8F3F9 sceNpDrmProcessExitSpawn2
 0x4C9F8F7A cellMgVideoUpdateICV
@@ -6826,18 +6826,18 @@
 0xFAFD69A4 __sys_net_lib_calloc
 0xF3F974B8 cellMinisSaveDataFixedSave
 0xF12CE769 sceNpFbUtilStreamPublish
-0xBAABCA85 _ZN4xMMS15GetValuePointerEPvjP15eMmsDbFieldTypePS0_Pj
+0xBAABCA85 xMMS::GetValuePointer(void*, unsigned int, eMmsDbFieldType*, void**, unsigned int*)
 0x5B546CA4 cellPngEncEncodePicture
 0x509D1588 cellAvsetInit
-0xDF1E09E1 _ZNKSt5ctypeIwE9do_narrowEPKwS2_cPc
+0xDF1E09E1 std::ctype<wchar_t>::do_narrow(wchar_t const*, wchar_t const*, char, char*) const
 0x4E88C68D _cellSyncLFQueueCompletePushPointer
 0x8DF28FF9 cellFsStReadStart
-0x9D191F72 _ZN3paf8DateTime13SetDateFormatEPKw
+0x9D191F72 paf::DateTime::SetDateFormat(wchar_t const*)
 0xC96E89E9 cellAudioOutSetCopyControl
 0xEBE5F72F sys_spu_image_import
 0x4109D08C cellAudioGetPortTimestamp
 0x967A162B cellFsFsync
-0xDC0C889C _ZNSt8ios_base7copyfmtERKS_
+0xDC0C889C std::ios_base::copyfmt(std::ios_base const&)
 0x73931BD0 sceNpBasicGetBlockListEntryCount
 0xCAAF7AE7 cprojf
 0x9F78F052 cos
@@ -6847,7 +6847,7 @@
 0xD8465650 svc1dGetPicture
 0xFBF5FE40 cellFiberPpuSetPriority
 0x75F98579 wcscoll
-0x0D1BA494 _ZN3paf10PhInfoList13SetSelectableEibb
+0x0D1BA494 paf::PhInfoList::SetSelectable(int, bool, bool)
 0x49CC902D _cellAudioAudioPathThroughLRCK_returnToNormal
 0x018A1381 cellSysutilAvcSetLayoutMode
 0x5F8BF2CC ft_synthesize_vertical_metrics
@@ -6856,11 +6856,11 @@
 0x186B98D3 cellSailPlayerGetRegisteredProtocols
 0x650A537E cellKbConfigAssignPortID
 0x42838145 HZstoUTF8s
-0xA74E5A27 _ZNKSt6localeeqERKS_
+0xA74E5A27 std::locale::operator== (std::locale const&) const
 0xBC04348D cellFt2dCreate
 0x3CABD075 cellCryptoPuSha1Final
 0x01379FD7 sceNpMatching2DestroyContext
-0x05229228 _ZN20MmsMdImporterContextD1Ev
+0x05229228 MmsMdImporterContext::~MmsMdImporterContext()
 0x7CAF58EE sceNpTusCreateTitleCtx
 0xC9607D35 _Stopfx
 0x52AADADF sys_lwcond_signal_to
@@ -6873,11 +6873,11 @@
 0x5EBE9FD4 FT_Stream_GetShortLE
 0x4D4A094C sceNpCommerce2Term
 0xE03C7AB1 _Fspos
-0x9CE5DD90 _ZN4xMMS11AsyncSearchEPvS0_P21xMMSSearchParameter_tPS0_
+0x9CE5DD90 xMMS::AsyncSearch(void*, void*, xMMSSearchParameter_t*, void**)
 0xC1786C81 cellImeJpSetFixInputMode
-0xDD0991D2 _ZN4xMMS8GetTotalEPvPi
-0x50CDB465 _ZN3paf4View8GetSoundEPKc
-0x1CE8C914 _ZN4cell5Daisy22ScatterGatherInterlock7releaseEv
+0xDD0991D2 xMMS::GetTotal(void*, int*)
+0x50CDB465 paf::View::GetSound(char const*)
+0x1CE8C914 cell::Daisy::ScatterGatherInterlock::release()
 0xC10931CB cellSpursCreateTasksetWithAttribute
 0xB3226E6A cellApostSrcTruncateHandle
 0x2CB51F0D cellFsClose
@@ -6896,13 +6896,13 @@
 0x01FBBC9B sceNpBasicSendMessageGui
 0x44F4A936 Heap_Create
 0xE562F820 cellFsUtilitySetupHdd10GBForLinuxWithCallback
-0xEE8F2CC4 _ZN4mat4ixEi
+0xEE8F2CC4 mat4::operator[] (int)
 0x674BB9FF sceNpCommerceGetProductCategoryAbort
-0xAF9AF4F4 _ZN3paf5PhWeb20SetChangeUrlCallbackEPFvPS0_PKwE
+0xAF9AF4F4 paf::PhWeb::SetChangeUrlCallback(void (*)(paf::PhWeb*, wchar_t const*))
 0xEEC22809 cellSailSoundAdapterUpdateAvSync
 0x4643BA6E sys_mmapper_unmap_memory
 0xE6F2C1E7 sys_process_exit
-0xF57E3590 _ZN3paf7PhMicon9SetRepeatEi
+0xF57E3590 paf::PhMicon::SetRepeat(int)
 0xA93E4417 cellAvcEncSetEndPoint
 0x05AE48E7 cellCryptoPuRsaep2048
 0xC95B20D3 fputwc
@@ -6912,57 +6912,57 @@
 0x8CCDBA38 UTF8stoUTF32s
 0x71117EFB sceNpMatching2GetRoomMemberIdListLocalVsh
 0x8FF22D5A scePS2McIconSys_GetAmbientColor
-0x7D594F19 _ZN3paf14PhLabelPrimDivC1EPNS_8PhWidgetEPNS_8PhAppearE
-0xDDD4ACF6 _ZN3paf11PhLabelText10WidgetTypeEv
+0x7D594F19 paf::PhLabelPrimDiv::PhLabelPrimDiv(paf::PhWidget*, paf::PhAppear*)
+0xDDD4ACF6 paf::PhLabelText::WidgetType()
 0x0C08DD3A FTC_Manager_New
 0x7687D48C sys_net_set_resolver_configurations
 0x5C1E2BCA cellGcmSetDrawIndexArray
-0x9624DDC9 _ZN3paf8PhXmList12SetItemAlphaEfff
+0x9624DDC9 paf::PhXmList::SetItemAlpha(float, float, float)
 0xB89105CA cellDtcpIpSeek
 0x8ECAE294 nextafter
 0x0D05DA19 cellCryptoPuRsaep1024
 0xA33FC21C cellKbConfigReleasePortID
-0x14B72562 _ZNK3paf9PhSRender12SetupTextureERKNS_12SurfaceRCPtrINS_7SurfaceEEERK4vec4
+0x14B72562 paf::PhSRender::SetupTexture(paf::SurfaceRCPtr<paf::Surface> const&, vec4 const&) const
 0xA74396E5 cellPadDbgLddRegisterController
 0xCE02F174 sceNetXmppSendExtMessage
 0xCF863219 _Fwprep
-0x1648672A _ZN3paf7PhMiconC2EPNS_8PhWidgetEPNS_8PhAppearEP12malloc_state
+0x1648672A paf::PhMicon::PhMicon(paf::PhWidget*, paf::PhAppear*, malloc_state*)
 0xC485D207 cellSpursJobQueuePort2Destroy
 0x5F3811F8 cellSysutilAvc2GetPlayerVoiceMuting
 0x83FAA354 cellHttpUtilBase64Encoder
 0x51E7CC21 cellSysutilSharedMemoryAlloc
 0xDEBEE2AF strchr
 0xDBDB909F sceNpCommerceGetDataFlagStart
-0x64527FA9 _ZN3paf10DecompressEPvjPKvj
+0x64527FA9 paf::Decompress(void*, unsigned int, void const*, unsigned int)
 0x5FCB6457 cellGcmSetBlendEquation
 0xC5F4CF82 sceNpScoreDestroyTransactionCtx
-0x15FD7978 _ZN3paf10PhProgress15RequestSetValueEf
+0x15FD7978 paf::PhProgress::RequestSetValue(float)
 0xF16379FA cellFontUnbindRenderer
 0x3F6262B3 f_fminf
 0x01F04D94 cellSysutilGamePowerOff_I
 0x9E83CC61 sceNpSetUserIcon
-0x4A48FC30 _ZN3paf7PhMicon14SetVolumeDeltaEf
+0x4A48FC30 paf::PhMicon::SetVolumeDelta(float)
 0xD83AB0C9 cellSync2QueuePop
 0x8ED71E8B _WGetfld
-0x61F55C30 _ZNKSt5ctypeIcE8do_widenEc
+0x61F55C30 std::ctype<char>::do_widen(char) const
 0x7E9FA832 naacEncEncode
-0xFEB981E6 _ZN3vsh11ContentInfo4HideEff
+0xFEB981E6 vsh::ContentInfo::Hide(float, float)
 0x4FA5AD09 cellSailPlayerReopenEsAudio
 0xFD58F18A _sce_net_get_name_server
 0x69FF1B9B fseek
-0xBEDFF5EE _ZN3paf10PhInfoList14GetPartsWidgetEi
+0xBEDFF5EE paf::PhInfoList::GetPartsWidget(int)
 0x7C2F4034 cellFiberPpuCreateFiber
 0xE3C424B3 cellHttpTransactionGetSslCipherString
 0x3261A9C8 cellWebBrowserConfigSetDisableTabs
-0x55FE8B14 _ZN3paf8PhXmItem10BlinkStartEf
+0x55FE8B14 paf::PhXmItem::BlinkStart(float)
 0x9CE52809 SBCSstoUCS2s
 0x640806D0 cellTiffDecExtReadHeader
-0x3F8C6AED _ZN3vsh10ScrollText4StopEv
-0xFC825DDA _ZNSt7num_putIwSt19ostreambuf_iteratorIwSt11char_traitsIwEEE7_GetcatEPPKNSt6locale5facetE
+0x3F8C6AED vsh::ScrollText::Stop()
+0xFC825DDA std::num_put<wchar_t, std::ostreambuf_iterator<wchar_t, std::char_traits<wchar_t>>>::_Getcat(std::locale::facet const**)
 0xBFDA6837 _f_log10f
 0xC94B27E3 _WStof
 0x7D02A5CA sqrtf4fast
-0x07047F37 _ZN3paf8PhXmList8BlinkEndEf
+0x07047F37 paf::PhXmList::BlinkEnd(float)
 0xA70737DA cellRudpFlush
 0xF133FB78 cellKbConfigSetRepeat
 0x40D40544 cellFontEndLibrary
@@ -6973,26 +6973,26 @@
 0x4217B4CF difftime
 0x153B364A mkdir
 0x558700F6 cellGameUpdateCheckStartWithoutDialogAsyncEx
-0x5298EF8E _ZdaPvRKSt9nothrow_t
+0x5298EF8E operator delete[](void*, std::nothrow_t const&)
 0xA322DB75 cellVideoOutGetResolutionAvailability
-0xD774E03E _Z19mat4_from_translatefff
+0xD774E03E mat4_from_translate(float, float, float)
 0xF9B1896D SJISstoUCS2s
-0xF65EFFC9 _ZN4xMMS15CreateSortChainEPPv
+0xF65EFFC9 xMMS::CreateSortChain(void**)
 0xF2B3338A sceNpBasicGetBlockListEntry
-0x9379F77A _ZN3paf8PhWidget8GetStyleEiR4vec4
-0x4B619490 _ZN3paf8PhWidget14GetLayoutStyleEiRiS1_S1_R4vec4
+0x9379F77A paf::PhWidget::GetStyle(int, vec4&)
+0x4B619490 paf::PhWidget::GetLayoutStyle(int, int&, int&, int&, vec4&)
 0x1C2EF212 getwc
 0xB153629C cellPngDecGetgAMA
-0x5E671849 _Z11pafGumScalePK4vec3
+0x5E671849 pafGumScale(vec3 const*)
 0xB2176B06 cellDtcpIpStopSequence
 0xC4E51FBF sceNpTusDeleteMultiSlotVariableVUser
 0x288F78EC cellGcmSetVertexData1f
-0x402E693B _ZN3paf6PhText6LineUpEj
-0xAE7D042F _ZNSt7codecvtIwcSt9_MbstatetE7_GetcatEPPKNSt6locale5facetE
+0x402E693B paf::PhText::LineUp(unsigned int)
+0xAE7D042F std::codecvt<wchar_t, char, std::_Mbstatet>::_Getcat(std::locale::facet const**)
 0xEC7DA0C8 _atan2f4fast
 0x1B4C3FF0 atexit
 0xE315A0B2 cellGcmGetConfiguration
-0xBB4599C5 _ZNSt11logic_errorD1Ev
+0xBB4599C5 std::logic_error::~logic_error()
 0x455C4709 cellSailRecorderDestroyVideoConverter
 0x1BCDEB47 _LSinh
 0xA058E135 msmw_LockUnlock
@@ -7003,29 +7003,29 @@
 0xC6D7EC13 sys_dbg_unregister_ppu_exception_handler
 0x0BB036A6 _cosf4
 0x02955295 cellUsbPspcmRecvAsync
-0xA98865F8 _ZN3paf10PhMenuList10WidgetTypeEv
+0xA98865F8 paf::PhMenuList::WidgetType()
 0x8EA23DEB cellHttpUtilMergeUriPath
 0xA1F43AD5 cellGcmSetViewport
-0xCE653B6C _ZNSt6_MutexC2Ev
-0x34EDD72B _ZNSt10moneypunctIwLb0EED1Ev
+0xCE653B6C std::_Mutex::_Mutex()
+0x34EDD72B std::moneypunct<wchar_t, false>::~moneypunct()
 0xC8DD9279 expm1
 0x77F5413F cellGcmSetTwoSidedStencilTestEnable
 0x1E585B5D cellNetCtlGetInfo
 0x1A2704F7 sceNpScoreWaitAsync
 0xE1DF9ABC Zi8InitializeDynamic
-0xCF52B916 _ZN3paf10PhSPrimDiv8SetStyleEii
+0xCF52B916 paf::PhSPrimDiv::SetStyle(int, int)
 0xB79012BA modff
 0x46CFC013 cellAtracAddStreamData
 0xF9883D3B cellUsbPspcmRecv
-0xE77FAFB5 _ZN8cxmlutil6SetIntERKN4cxml7ElementEPKci
+0xE77FAFB5 cxmlutil::SetInt(cxml::Element const&, char const*, int)
 0xFA020C41 sceNetCtlConnectWithRetryVsh
 0x2452679F cellKeySheapMutexDelete
 0x90010029 gets
 0x67D6334B strtof
 0xFA765D42 _Cdivcr
 0xD6F3FC82 cellRemotePlayStopPeerVideoOut
-0xC560907A _ZN3vsh3fim18getMePresenceStateEv
-0x9DCB4BCB _ZNKSt8time_getIwSt19istreambuf_iteratorIwSt11char_traitsIwEEE14do_get_weekdayES3_S3_RSt8ios_baseRNSt5_IosbIiE8_IostateEPSt2tm
+0xC560907A vsh::fim::getMePresenceState()
+0x9DCB4BCB std::time_get<wchar_t, std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>>::do_get_weekday(std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>, std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>, std::ios_base&, std::_Iosb<int>::_Iostate&, std::tm*) const
 0x5A23DB5B FT_Raccess_Get_DataOffsets
 0x39D44176 FT_Get_First_Char
 0x21A37B3E log1pf
@@ -7037,26 +7037,26 @@
 0xB4335A81 cellNetAoiGetRemotePeerInfo
 0x90460081 cellUsbdUnregisterExtraLdd
 0x923DB0DA cellTiffDecReadHeader
-0xE014D3BA _ZN3paf4View12StopSoundAllEv
+0xE014D3BA paf::View::StopSoundAll()
 0x40B33058 scePS2McIconSys_GetLightColor1
-0x07B37EB7 _ZN3paf5PhWeb25SetNotifyShutdownCallbackEPFvPS0_bE
-0x0CC64396 _ZN3vsh11ContentInfo10SetTextureERKN3paf12SurfaceRCPtrINS1_7SurfaceEEEi
+0x07B37EB7 paf::PhWeb::SetNotifyShutdownCallback(void (*)(paf::PhWeb*, bool))
+0x0CC64396 vsh::ContentInfo::SetTexture(paf::SurfaceRCPtr<paf::Surface> const&, int)
 0x8A96E574 cellPngEncCoreOpen
-0x165AD4A6 _ZN3paf7PhSText8SetStyleEif
-0xF1CFF87D _ZNSt10ctype_baseD2Ev
+0x165AD4A6 paf::PhSText::SetStyle(int, float)
+0xF1CFF87D std::ctype_base::~ctype_base()
 0x033C4905 cellSslCertGetRsaPublicKeyExponent
 0x97C85E96 cellGcmSetTextureOptimization
 0x20A97BA2 cellPadLddRegisterController
 0xE12F7196 cellAsfParser2AStdSeekTime
 0x0E5CEE1B sceNpMatching2GetClanLobbyIdVsh
-0x12F2B781 _ZN3paf8PhXmList17SetOtherItemAlphaEfff
-0x2E5D1BB3 _ZNK3paf7PhTimer6DoFuncEfi
-0x68596AF1 _ZN3paf11SurfaceCLUTC1EPNS_11SurfacePoolE9ImageModei
+0x12F2B781 paf::PhXmList::SetOtherItemAlpha(float, float, float)
+0x2E5D1BB3 paf::PhTimer::DoFunc(float, int) const
+0x68596AF1 paf::SurfaceCLUT::SurfaceCLUT(paf::SurfacePool*, ImageMode, int)
 0x90B9465E cellFontRenderSurfaceInit
 0xC747F231 FTC_SBit_Cache_New
 0x89801F5D sceNpC7yTusDestroyTransactionVsh
 0xDB819E03 cellUsbdGetDeviceLocation
-0x278774DE _ZN3paf7SurfacenwEj
+0x278774DE paf::Surface::operator new(unsigned int)
 0xAC78C1F3 sceNpCommerce2GetContentRatingInfoFromCategoryInfo
 0xCBBC20B7 cellImeJpAllConvertCancel
 0x5ABD8B1E cellFontGetLibrary
@@ -7065,11 +7065,11 @@
 0xC815B219 sceNpTusDeleteMultiSlotDataVUserAsync
 0xEDC34E1A cellDiscGameUnregisterDiscChangeCallback
 0x4826DB61 fma
-0xDA6B5FAD _ZmlRK4mat4RK4vec4
+0xDA6B5FAD operator* (mat4 const&, vec4 const&)
 0x7A1B6EAB cellUsbdHSIsochronousTransfer
 0x0F428F0F rint
 0x5853BE79 sys_netset_if_down
-0xAB1C71B5 _ZNK7bXCeDoc11GetNodeNameEP8bXCeNode
+0xAB1C71B5 bXCeDoc::GetNodeName(bXCeNode*) const
 0x36D38701 cellImeJpReset
 0xCE3CCAE6 sceUpdateDownloadAbort
 0xFAE4B063 _Strcollx
@@ -7079,15 +7079,15 @@
 0xB17436B5 cellDtcpIpSetEncryptedDataEx
 0x276E33DC mios2_Client_Finalize
 0xCB6494D5 mvcDecFlush
-0xA94BE0FA _ZNSt13basic_filebufIwSt11char_traitsIwEE9_EndwriteEv
+0xA94BE0FA std::basic_filebuf<wchar_t, std::char_traits<wchar_t>>::_Endwrite()
 0xB7618526 sceNetApCtlDisconnectVsh
 0x218CFBD3 sceNetCtlInitVsh
 0xDD91F304 FT_Get_TrueType_Engine_Type
 0x6A024AA0 cellMicGetDeviceAttr
-0x25111EFB _ZN3vsh15BottomBar_CloseEPN3paf4ViewEPKcS4_RNS_21BottomBarInstanceDataEi
+0x25111EFB vsh::BottomBar_Close(paf::View*, char const*, char const*, vsh::BottomBarInstanceData&, int)
 0x0F02F882 llrintl
-0x80334194 _ZN3paf8PhXmList11SetItemTypeEii
-0xAED08D9E _ZN3paf6PhList18PushBackLabelImageEi
+0x80334194 paf::PhXmList::SetItemType(int, int)
+0xAED08D9E paf::PhList::PushBackLabelImage(int)
 0x0AF56D94 FT_Set_MM_Design_Coordinates
 0x4DA349B2 cellSyncQueueSize
 0x718BF5F8 cellFsOpen
@@ -7097,22 +7097,22 @@
 0x75080F7B _SceAdecCorrectPtsValue_truehd
 0x2803ABD1 FT_FloorFix
 0x19A2A967 cellRescSetPalInterpolateDropFlexRatio
-0x5DC484F8 _ZN3vsh10OptionMenu12ShadowRenderEv
-0x867956A4 _ZNSt9basic_iosIcSt11char_traitsIcEED1Ev
+0x5DC484F8 vsh::OptionMenu::ShadowRender()
+0x867956A4 std::basic_ios<char, std::char_traits<char>>::~basic_ios()
 0xD47CC666 cellHttpTransactionReleaseConnection
 0x7370D8D0 sceNpCommerce2GetCategoryContentsCreateReq
 0x19F7C8D1 cellAvcEncGetResult
 0x61CA5726 smf_FClose_M
 0x36F2B4ED strtoull
 0x0522D1AF _recipf4
-0x2D388628 _ZN3paf8DateTime13SetTimeFormatEPKw
-0xEF959A6D _ZThn8_NSt9strstreamD0Ev
+0x2D388628 paf::DateTime::SetTimeFormat(wchar_t const*)
+0xEF959A6D non-virtual thunk to std::strstream::~strstream()
 0x9D935729 cellMarlinDRMInitSession
 0x6DCEAFCA smf_ApPs_GetMovieDuration
 0x66D61138 xRegistryDestroyList
 0xDE2B44CF sceNpMatching2SendRoomMessageVsh
 0xF0E022C6 getc
-0x5119680B _ZNSt8_LocinfoD1Ev
+0x5119680B std::_Locinfo::~_Locinfo()
 0xDD6E2008 SSLCERT_get_extension
 0xACACB0C1 cellGcmSetVertexDataBase
 0xAC91830E cellGcmSetZcullStatsEnable
@@ -7120,7 +7120,7 @@
 0x526C2374 Platform_GetConfig
 0x496C6F50 _Getctyptab
 0x46DA529A epsonPrintGetStatus
-0xF58E83A5 _Znaj
+0xF58E83A5 operator new[](unsigned int)
 0x3A2D806C cellSailFutureGet
 0x2A138D2B truncf
 0x645557BD copysignl
@@ -7128,7 +7128,7 @@
 0xB9C79A02 cellGcmSetStencilTestEnable
 0xED9D1AC5 f_tanf
 0x318F17E1 _sys_memalign
-0x2B8E3B5B _ZN4xMMS15ReleaseMetadataEPv
+0x2B8E3B5B xMMS::ReleaseMetadata(void*)
 0x0FFACD6D pafGuGetVideoMemoryTotalArea
 0xA7B2103A cellFontDelete
 0xCFD82265 FT_Stroker_Rewind
@@ -7136,7 +7136,7 @@
 0x0D10FD3F module_prologue
 0xC391FCCB cellDSEEFreeHandle
 0xA0174014 cellMtpRecvResponse
-0x14A9CC1D _ZN4mat4C1Ef
+0x14A9CC1D mat4::mat4(float)
 0x9197915F cellSpursTaskGenerateLsPattern
 0x90457FE3 raw_spu_read_long
 0xF11B8DD5 cellAtracMultiGetChannel
@@ -7147,33 +7147,33 @@
 0xC9D09C34 recvmsg
 0x1E1B4C97 cellOskDialogExtRegisterKeyboardEventHookCallback
 0xAE6A21D5 cellVoiceConnectIPortToOPort
-0xEDFC8A87 _Z16xcbSetMusicCodecPv12MmsCodecType
+0xEDFC8A87 xcbSetMusicCodec(void*, MmsCodecType)
 0x64F66D35 connect
 0x3EC9DE23 _cbrtf4
 0x0C44F441 cellFiberPpuYield
 0x872A225C cellMgVideoEndMovie
-0x24EBED2B _ZN3paf9PhNumSpin7SetTextERKSbIwSt11char_traitsIwESaIwEEi
+0x24EBED2B paf::PhNumSpin::SetText(std::basic_string<wchar_t, std::char_traits<wchar_t>, std::allocator<wchar_t>> const&, int)
 0xD360DCB4 fileno
 0x607F56F9 cellMtpStop
 0xA10EDAE9 cellGcmSetColorMask
-0x2BD63EAD _ZN3paf8PhWidget13BeginEditTextERKNS_10PhEditText8OskParamEi
-0x99919819 _ZNK3paf4View8IsActiveEv
+0x2BD63EAD paf::PhWidget::BeginEditText(paf::PhEditText::OskParam const&, int)
+0x99919819 paf::View::IsActive() const
 0x7F6BE69F _cellAudioSetAppDuckingLevel
 0xE26BBDE4 InputDevice_Unlock
 0x1D35BFE4 _LLog
 0x30BA63C2 cellTiffDecExtDecodeData
-0x15084E9A _ZNK3paf7PhMicon8GetWidthEv
+0x15084E9A paf::PhMicon::GetWidth() const
 0xB4F4A829 SSL_CTX_new
 0xC3CB8558 sceNpMatching2ContextStartAsyncVsh
 0xBE8D5485 UCS2stoARIBs
 0x3EF4F668 cellSysutilAvc2GetSpeakerVolumeLevel
 0xFBD5C856 cellSaveDataAutoLoad2
-0x2954D64D _ZNSt13basic_filebufIwSt11char_traitsIwEE9underflowEv
+0x2954D64D std::basic_filebuf<wchar_t, std::char_traits<wchar_t>>::underflow()
 0x052A80D9 cellHttpCreateTransaction
 0xBEF63A14 SetRegistry2NetApCtlSetting
 0x45C89206 FTFaceH_GetEffectAdditionalWidth
 0x8F46325B sceNpCommerce2GetProductInfoStart
-0xF30D3407 _ZNKSt7num_putIwSt19ostreambuf_iteratorIwSt11char_traitsIwEEE6do_putES3_RSt8ios_basewd
+0xF30D3407 std::num_put<wchar_t, std::ostreambuf_iterator<wchar_t, std::char_traits<wchar_t>>>::do_put(std::ostreambuf_iterator<wchar_t, std::char_traits<wchar_t>>, std::ios_base&, wchar_t, double) const
 0x773BC9A9 FTRenderBuf_Init
 0xEF68C17C sys_prx_load_module_by_fd
 0x87C87495 sys_rsxaudio_finalize
@@ -7182,35 +7182,35 @@
 0x38479255 sceNetApCtlConnectVsh
 0x9DDB9DC3 sys_dbg_get_spu_thread_group_status
 0x03AEA906 divf4
-0x92A06C2B _ZN3paf9PhNumSpin8DrawThisEjb
+0x92A06C2B paf::PhNumSpin::DrawThis(unsigned int, bool)
 0xE1134B5D avcDecRlsFrame
 0xAB779874 module_stop
-0x964CE2DD _ZN4mat4C1Effffffffffffffff
+0x964CE2DD mat4::mat4(float, float, float, float, float, float, float, float, float, float, float, float, float, float, float, float)
 0xBB2877F2 sceNpTusGetMultiSlotVariableAsync
 0x2A8EADA2 cellSaveDataFixedLoad2
 0xA9879A33 sys_rsxaudio_create_connection
-0x75457863 _ZN3paf4View9PageCloseEPv
-0x078C1325 _Z16xcbGetMusicCodecPvP12MmsCodecType
+0x75457863 paf::View::PageClose(void*)
+0x078C1325 xcbGetMusicCodec(void*, MmsCodecType*)
 0x0125B2CA _rand_int32_TT800
 0xA297525E _cellSysutilGetSystemParamInt
 0x44D7CAE8 raw_spu_read_float
 0xAF3EBA5A sceNpCommerceDoCheckoutFinishAsync
 0xC2F38FF1 _sce_net_set_default_gateway
-0x4952490E _ZNSt8ios_base5clearENSt5_IosbIiE8_IostateEb
+0x4952490E std::ios_base::clear(std::_Iosb<int>::_Iostate, bool)
 0xEF87A695 sys_lwcond_signal
 0xDED17C26 sceNpScoreGetClansMembersRankingByNpId
 0x6E5906FD UCS2stoEUCJPs
 0x7A0329A1 cellFsAllocateFileAreaWithoutZeroFill
 0xABCB26A1 sys_netset_get_status
-0x5A3AD4BD _ZNKSt7num_getIcSt19istreambuf_iteratorIcSt11char_traitsIcEEE6do_getES3_S3_RSt8ios_baseRNSt5_IosbIiE8_IostateERf
+0x5A3AD4BD std::num_get<char, std::istreambuf_iterator<char, std::char_traits<char>>>::do_get(std::istreambuf_iterator<char, std::char_traits<char>>, std::istreambuf_iterator<char, std::char_traits<char>>, std::ios_base&, std::_Iosb<int>::_Iostate&, float&) const
 0x7C210A32 cellAvcEncSmallSendEncCommand
 0xAEE1E0C2 cellSubDisplayAudioOutBlocking
 0x31D9F435 sceNpFbUtilAbortTransaction
 0xB9F93BBB sceNpScoreCreateTitleCtx
-0x73C6B7C4 _ZN3paf8PhWidget16SetScale_ontimerERK4vec4
+0x73C6B7C4 paf::PhWidget::SetScale_ontimer(vec4 const&)
 0xC7F1D407 fmal
 0x55E0D461 cellFt2dVariance
-0x6AF9FD89 _ZN8cxmlutil16FindChildElementERKN4cxml7ElementEPKcS5_S5_
+0x6AF9FD89 cxmlutil::FindChildElement(cxml::Element const&, char const*, char const*, char const*)
 0x191F0C4A _sys_strrchr
 0x7F381837 frexp
 0x77A4C328 sqlite3_value_text16
@@ -7221,7 +7221,7 @@
 0x6E949735 sjvtdDecodePicture
 0xC0E27B2C _Makestab
 0x1989C62B at3enc_query_input_pcm_bytes
-0x34B63588 _ZNKSt5ctypeIwE9_DonarrowEwc
+0x34B63588 std::ctype<wchar_t>::_Donarrow(wchar_t, char) const
 0xE95BFC2C cellHttpGetMemoryInfo
 0xADD46D8E CESysCloseHandle
 0x2BE41ECE sceNpCommerceGetNumOfChildCategory
@@ -7235,8 +7235,8 @@
 0xD55DBC11 cellMusicDecodeInitialize
 0x4B4CBF7A FT_Outline_Embolden
 0x69C6CC82 cellGcmSetCursorDisable
-0x1C5F3492 _ZNK4cxml7Element12GetAttributeEPKcPNS_9AttributeE
-0x95082493 _ZNKSt8messagesIcE6do_getEiiiRKSs
+0x1C5F3492 cxml::Element::GetAttribute(char const*, cxml::Attribute*) const
+0x95082493 std::messages<char>::do_get(int, int, int, std::basic_string<char, std::char_traits<char>, std::allocator<char>> const&) const
 0x88214E8A __gxx_personality_v0
 0xA2B01449 sceNpMatching2GetSignalingOptParamLocal
 0xF8A175EC cellSaveDataAutoSave
@@ -7247,22 +7247,22 @@
 0x54AE2561 cellGcmSetScissor
 0x99FB73D1 cellAtracGetBufferInfoForResetting
 0x8A40A618 cellSysutilAvc2GetWindowSize
-0x2354EC0A _ZNKSt7codecvtIwcSt9_MbstatetE10do_unshiftERS0_PcS3_RS3_
+0x2354EC0A std::codecvt<wchar_t, char, std::_Mbstatet>::do_unshift(std::_Mbstatet&, char*, char*, char*&) const
 0xB9562C1A cellSailComposerTryGetEsAudioAu
 0xA121A224 cellSpursTaskAttributeSetExitCodeContainer
 0x0783BCE0 cellPhotoImport
 0x8AAE07C2 cellSync2CondSignalAll
 0x0B712E67 set_npflashplayer9_dllentry
-0x8867A000 _ZN4xMMS14UpdateMetadataEyPv
+0x8867A000 xMMS::UpdateMetadata(unsigned long long, void*)
 0xB6DF2D46 epsonPrintStartJob
-0xF744FE00 _ZN3paf7PhXmBar11ScrollRightEfPNS_7PhEventE
+0xF744FE00 paf::PhXmBar::ScrollRight(float, paf::PhEvent*)
 0xD8B4EB20 __spu_thread_puttxt
 0x0CAE547F raw_spu_write_double
 0x60ACD240 SSLCERT_get_basic_constraints_int
 0x0E53319F _asinf4
-0xF7845D1C _ZNSt7_MpunctIcED1Ev
+0xF7845D1C std::_Mpunct<char>::~_Mpunct()
 0xE075FABC cellDmuxOpenExt
-0x90EC7BF6 _ZN10PSJSObject7DelAttrERK8psjsname
+0x90EC7BF6 PSJSObject::DelAttr(psjsname const&)
 0xF5FF5F31 sceNpUtilCmpNpIdInOrder
 0xE21F35DE cellAvcEncSmallCancelFrame
 0x56178BAA _cellAudioSetRsxRelayedSetting
@@ -7274,7 +7274,7 @@
 0xE806D0F2 cellPngEncCoreOpen2
 0x6FFAE9BA cellMtpStart
 0xFB3341BA cellFontSetResolutionDpi
-0xB44C7BB5 _ZN4xMMS30DeleteMetadataSetWithThumbnailEjPKy
+0xB44C7BB5 xMMS::DeleteMetadataSetWithThumbnail(unsigned int, unsigned long long const*)
 0xFCAC2E8E mbstowcs
 0xF926D22F FTC_ImageCache_Lookup
 0xCB0F348A cellAvcEncSmallGetVersion
@@ -7282,23 +7282,23 @@
 0x62B3B135 cellTiffDecDecodeData
 0x2BB0F2C9 logb
 0x7D6191D0 _Cosh
-0x2B05B95A _ZNKSt7_MpunctIcE11do_groupingEv
-0x8CDA1F3B _ZSt10_GetloctxtIcSt19istreambuf_iteratorIcSt11char_traitsIcEEEiRT0_S5_jPKT_
+0x2B05B95A std::_Mpunct<char>::do_grouping() const
+0x8CDA1F3B int std::_Getloctxt<char, std::istreambuf_iterator<char, std::char_traits<char>>>(std::istreambuf_iterator<char, std::char_traits<char>>&, std::istreambuf_iterator<char, std::char_traits<char>>&, unsigned int, char const*)
 0xA0657A3D atxenc_get_build_condition
 0x73A2E36B sceNpMatchingGetRoomMemberListLocal
-0x304EAE6F _ZNK3paf6PhText12GetFirstLineEv
+0x304EAE6F paf::PhText::GetFirstLine() const
 0x501C412F cargf
-0xC013ACD8 _ZNSt8ios_base8_CallfnsENS_5eventE
+0xC013ACD8 std::ios_base::_Callfns(std::ios_base::event)
 0xD3346DC4 sceNpClansRemovePostedChallenge
 0x80B711CE cellSailRecorderRegisterComposer
 0x806960AB sceNpBasicRecvMessageCustom
 0x9E3B1E16 cellFontAdjustGlyphExpandBuffer
 0x32E4A30A _Mtxdst
 0x4DDB926B powf
-0x38783BEB _ZNKSt8time_getIcSt19istreambuf_iteratorIcSt11char_traitsIcEEE11do_get_yearES3_S3_RSt8ios_baseRNSt5_IosbIiE8_IostateEPSt2tm
+0x38783BEB std::time_get<char, std::istreambuf_iterator<char, std::char_traits<char>>>::do_get_year(std::istreambuf_iterator<char, std::char_traits<char>>, std::istreambuf_iterator<char, std::char_traits<char>>, std::ios_base&, std::_Iosb<int>::_Iostate&, std::tm*) const
 0x0B411261 FTC_Manager_LookupFace
 0xA9B62AC8 cellWebBrowserConfigSetViewRect2
-0xFC563813 _ZNKSt7codecvtIccSt9_MbstatetE5do_inERS0_PKcS4_RS4_PcS6_RS6_
+0xFC563813 std::codecvt<char, char, std::_Mbstatet>::do_in(std::_Mbstatet&, char const*, char const*, char const*&, char*, char*, char*&) const
 0x91412F37 cellFt2dOpen
 0x1B5A0282 cellCryptoPuRsassaPkcs1v15Verify2048
 0x8B439438 clearerr
@@ -7308,20 +7308,20 @@
 0x838FA4F0 cellSpursTryJoinTask2
 0x2388186C cellFontGraphicsGetScalePixel
 0xC0BCF25E _logf4fast
-0xE2B2AC5A _ZNSt6locale5facet9_RegisterEv
+0xE2B2AC5A std::locale::facet::_Register()
 0x98C9D162 _cellAudioSysSpuChainSetId
 0x51B09E1D FT_Open_Face
-0xD14F5F81 _ZN3paf9PhNumSpin8SetStyleEiii
+0xD14F5F81 paf::PhNumSpin::SetStyle(int, int, int)
 0xB489C8C3 cellDecPsnvideoFreeProfiler
 0x1EFB3790 pafGuBlendFunc
-0x7F0930C6 _ZN3paf6PhTextC1EPNS_8PhWidgetEPNS_8PhAppearE
-0xBD35830B _ZdaPvjS_
+0x7F0930C6 paf::PhText::PhText(paf::PhWidget*, paf::PhAppear*)
+0xBD35830B operator delete[](void*, unsigned int, void*)
 0xEBB4E08A hypotf
-0x8E3B155F _ZN3paf7PhSText8SetStyleEib
+0x8E3B155F paf::PhSText::SetStyle(int, bool)
 0xBA49D65A sjvtdSetAuxData
-0x2F5CEE6D _ZN3paf6ModuleD1Ev
+0x2F5CEE6D paf::Module::~Module()
 0x612496AA cellFsUtilGetMountInfo
-0xD8BFCC6C _Z25xcbGetExtensionFromRecordPvPcPi
+0xD8BFCC6C xcbGetExtensionFromRecord(void*, char*, int*)
 0xEB26298C gmtime
 0xE2E821B5 smf_ApCm_NewMovie
 0xD6ABD5BF cellFt2dTransformFormat
@@ -7333,7 +7333,7 @@
 0x1A5B72DD smvd2DecodePicture2
 0x37A1A412 cellAsfParser2SeekPacketOffset
 0xA1BFE761 cellGcmSetTimeStamp
-0x63D446B8 _ZN3paf8PhWidget8DrawThisEjb
+0x63D446B8 paf::PhWidget::DrawThis(unsigned int, bool)
 0x1096F8F1 ispunct_ascii
 0x5F5B3227 cellImeJpGetFocusLength
 0x6CC4BD13 casinh
@@ -7342,22 +7342,22 @@
 0x8AA68668 cellNetAoiStop
 0x7F91CD41 tanf4fast
 0xAA16695F sceNpDrmProcessExitSpawn
-0xE7AA1971 _ZN3vsh3fim16friendAddRequestEP7SceNpIdiP24SceNetXmppInstantMessagePFiiPvES5_
-0xF67A7E17 _ZNSt13basic_filebufIwSt11char_traitsIwEE5uflowEv
-0x9F959451 _ZNSt13basic_istreamIwSt11char_traitsIwEED1Ev
+0xE7AA1971 vsh::fim::friendAddRequest(SceNpId*, int, SceNetXmppInstantMessage*, int (*)(int, void*), void*)
+0xF67A7E17 std::basic_filebuf<wchar_t, std::char_traits<wchar_t>>::uflow()
+0x9F959451 std::basic_istream<wchar_t, std::char_traits<wchar_t>>::~basic_istream()
 0xBEC43F86 raw_spu_read_ptr
 0x93427CB9 setbuf
 0xEE2731D3 _SceAdecCorrectPtsValue_Ddp
 0xF88E07DB _QN4cell5Daisy4Lock18getNextTailPointerEv
 0xD297EF28 sceNpCommerceGetProductCategoryAbortVsh
 0x28B22E44 cellPhotoDecodeFromFile
-0xEC7C4469 _ZN3paf7PhXmBar9HideLabelEiff
+0xEC7C4469 paf::PhXmBar::HideLabel(int, float, float)
 0x44567B8F ERR_clear_error
 0xE4347E6B ft_stub_set_pixel_sizes
 0x97409F67 cellSpursJobQueueSemaphoreTryAcquire
 0xFB793F27 cellRemotePlayBreak
 0x99A6C261 catanf
-0xD822049A _ZN11PSJSContext14RegistStandardEv
+0xD822049A PSJSContext::RegistStandard()
 0xAFF7627A _cellSyncLFQueueGetSignalAddress
 0x148F58A7 cellDivXDrmDecryptAudioFrame
 0x56C573A8 log1p
@@ -7366,46 +7366,46 @@
 0x3099B063 _cellGcmFunc17
 0x59432970 sceNpTusSetTimeout
 0xDD0C1E09 _sys_spu_printf_attach_group
-0xF6E0A48F _ZN3paf8PhWidget14SetLayoutStyleEiif
+0xF6E0A48F paf::PhWidget::SetLayoutStyle(int, int, float)
 0xF125E044 cellSync2QueueInitialize
 0xCEE3C5A0 FT_Set_MM_Blend_Coordinates
 0x76CA1B53 cellGcmSetCullFace
 0x8A61B8A8 sceNpFbUtilCreateTransaction
-0xEAD0EFAC _ZN3Ime21OskCreateInputContextEPNS_17ImeOskCreateParamE
+0xEAD0EFAC Ime::OskCreateInputContext(Ime::ImeOskCreateParam*)
 0xDC14974C fmaf4
 0x540D9068 cellSearchGetOffsetByContentId
 0x59B1EDE1 cellGameGetHomeDataExportPath
 0x807C861A cellVdecGetPicture
 0x8FC281F7 cellHttpCookieFlush
 0x20472DA0 sceNpClansGetMemberInfo
-0xB36CA4B4 _ZN3paf8PhWidget14GetLayoutStyleEiiRiRf
+0xB36CA4B4 paf::PhWidget::GetLayoutStyle(int, int, int&, float&)
 0x9C1A2D6A pafGuSetDrawSurfH
 0x7F4A8B0E cellDtcpIpInitializeAuthentication
-0xA2FD0EC5 _ZNSt13basic_filebufIcSt11char_traitsIcEE9pbackfailEi
+0xA2FD0EC5 std::basic_filebuf<char, std::char_traits<char>>::pbackfail(int)
 0xBEFE3869 isSjisKigou
 0x26090058 sys_prx_load_module
 0x4659CA92 cellDtcpIpFinalize
 0xA79E286A CEComCalloc
-0x2AE9F5B2 _ZN3paf5PhWeb17SetDialogCallbackEPFiNS0_12UISessionPtrEPKwS3_Ei
+0x2AE9F5B2 paf::PhWeb::SetDialogCallback(int (*)(paf::PhWeb::UISessionPtr, wchar_t const*, wchar_t const*), int)
 0xFF0309A5 Pool_QueryInfo
 0xC2BB48BC cellImeJpConvertBackward
-0xE607C2BA _ZN3vsh10OptionMenu4ShowEv
+0xE607C2BA vsh::OptionMenu::Show()
 0x5D9A7034 cellFiberPpuSelf
 0xCEB2EB36 cellImeJpOpenExt
 0xBB68D76E cellSpursJobChainAttributeSetHaltOnError
 0x1EF115EF cellSysmoduleGetImagesize
 0x0264F468 _Wctomb
-0x8C3AFD4C _ZSt10unexpectedv
+0x8C3AFD4C std::unexpected()
 0xA6669751 cellSyncRwmTryRead
 0x8B73A9EF ATEdeleteWordExpr
 0x3A7075F2 cellPostNrExec
-0x64CE0374 _ZNSbIwSt11char_traitsIwESaIwEE7replaceEjjPKwj
+0x64CE0374 std::basic_string<wchar_t, std::char_traits<wchar_t>, std::allocator<wchar_t>>::replace(unsigned int, unsigned int, wchar_t const*, unsigned int)
 0x92CC4B34 cellGemGetImageState
 0xEB51AA38 cellPrintUnloadAsync
 0x23009D07 sceNpMatching2Term2
 0xBEFAD0E2 cellCryptoPuAesEncrypt
 0xD8C9C9A3 cellM4vEncReleaseLocalDecodedFrame
-0x33944117 _ZN3paf14Job_isCanceledEPNS_10Job_ThreadE
+0x33944117 paf::Job_isCanceled(paf::Job_Thread*)
 0xA114EC67 cellGcmMapMainMemory
 0x58D58FCF cellSpursTasksetGetSpursAddress
 0xA10195F4 cellSsUmGetStatus
@@ -7430,7 +7430,7 @@
 0xDBA27BC1 scePS1McHeader_GetTitleNameForChina
 0xFE9BEE8C ft_module_get_service
 0x4F1B4FCC sceLoginServiceNetworkCreate
-0xD8D768ED _ZN3paf12PhLevelMeter11SetSelectedEi
+0xD8D768ED paf::PhLevelMeter::SetSelected(int)
 0x10DB5B1A cellRescSetDsts
 0xFA304515 cellAvsetEnableEvent
 0x67D56767 FT_Get_SubGlyph_Info
@@ -7444,50 +7444,50 @@
 0x99AC9952 sceNpCommerceSetDataFlagStart
 0x4C751D97 cellPadConfigReleasePortID
 0x56D3A5AB sceNpTssGetData
-0xAE3205B7 _ZN3paf7PhMicon20GetActivePlayerCountEv
+0xAE3205B7 paf::PhMicon::GetActivePlayerCount()
 0xB3516536 cellUserInfoEnableOverlay
 0x27C69EBA sceNpBasicAddFriend
 0xE75FDA8D xRegistryAddKey
 0xB015A84E cellFontGetRevisionFlags
 0x285D30D6 cellFontGetScalePixel
-0xBA6B47F2 _ZNK3paf7PhMicon9GetRepeatEv
-0x1A7A9C16 _ZN23xMMSMdGeneratorReceiver20GetMediaInfoFromPathEPKhP21xMMSGenerateStorageId
+0xBA6B47F2 paf::PhMicon::GetRepeat() const
+0x1A7A9C16 xMMSMdGeneratorReceiver::GetMediaInfoFromPath(unsigned char const*, xMMSGenerateStorageId*)
 0x3CC27344 sceNpMatching2GetRoomSlotInfoLocal
-0xDD8B1D47 _ZNSs5eraseEjj
+0xDD8B1D47 std::basic_string<char, std::char_traits<char>, std::allocator<char>>::erase(unsigned int, unsigned int)
 0x9412E394 cellAvcEncQueryPresetParameter
 0xFE669845 cellWebBrowserConfigSetHeapSize2
 0xA6CEADF0 cellGcmSetVertexData4ub
-0x2A16469D _ZNSt8ios_base5imbueERKSt6locale
-0x58B963E5 _ZN4cxml7Element11AppendChildERS0_
+0x2A16469D std::ios_base::imbue(std::locale const&)
+0x58B963E5 cxml::Element::AppendChild(cxml::Element&)
 0x617EEC02 cellHttpClientDeleteHeader
-0xF8DB34C7 _ZN3paf7PhClock15SetShadowRenderEPNS_9PhSRenderE
+0xF8DB34C7 paf::PhClock::SetShadowRender(paf::PhSRender*)
 0xF9D31F75 FT_Attach_Stream
 0x6D367953 sys_config_stop
 0xC7622586 cellGemHSVtoRGB
-0x6846D51A _ZN3paf8PhWidget12ReleaseFocusEb
+0x6846D51A paf::PhWidget::ReleaseFocus(bool)
 0x77F2A468 cellGcmSetTextureFilter
 0xE66BAC36 console_putc
 0xD7F43016 module_info
 0xFC52A7A9 sys_game_process_exitspawn
-0x2D7C1B40 _ZNK10PSJSObject10IsSubClassEPKt
+0x2D7C1B40 PSJSObject::IsSubClass(unsigned short const*) const
 0x904E646B cargl
-0x9C40D1F9 _ZNKSt8numpunctIwE16do_decimal_pointEv
+0x9C40D1F9 std::numpunct<wchar_t>::do_decimal_point() const
 0x4E010403 copysign
 0x4C019248 mios2_Client_SharedMemoryFree
 0x1529E506 cellAdecDecodeAu
-0x2AC890F4 _ZNKSt7num_getIcSt19istreambuf_iteratorIcSt11char_traitsIcEEE6do_getES3_S3_RSt8ios_baseRNSt5_IosbIiE8_IostateERb
+0x2AC890F4 std::num_get<char, std::istreambuf_iterator<char, std::char_traits<char>>>::do_get(std::istreambuf_iterator<char, std::char_traits<char>>, std::istreambuf_iterator<char, std::char_traits<char>>, std::ios_base&, std::_Iosb<int>::_Iostate&, bool&) const
 0x638C2FC1 SjisHan2Zen
 0x8A4FEA82 cellExifPrintDirectory
 0x79225AA3 sceNpCommerceGetCurrencyCode
 0xF68E2AC9 _init_malloc_lock
 0x64243044 ft_lzwstate_done
-0x1C83C0B6 _ZN3paf8PhScroll16SetVisibleAmountEf
+0x1C83C0B6 paf::PhScroll::SetVisibleAmount(float)
 0xFFC74003 cellHttpClientGetPerHostPoolSize
-0x6BE9B314 _ZN3paf7PhSText14SetLayoutStyleEiif
+0x6BE9B314 paf::PhSText::SetLayoutStyle(int, int, float)
 0xC94FCC63 cbrtl
 0x853BE146 _sce_net_add_name_server_with_char
 0x13EA7C64 cellGemInit
-0x3BDA45A7 _ZNKSt7num_putIcSt19ostreambuf_iteratorIcSt11char_traitsIcEEE6do_putES3_RSt8ios_basecy
+0x3BDA45A7 std::num_put<char, std::ostreambuf_iterator<char, std::char_traits<char>>>::do_put(std::ostreambuf_iterator<char, std::char_traits<char>>, std::ios_base&, char, unsigned long long) const
 0xF7AC8941 gethostbyaddr
 0xDFA9D08D sceAdGetSpaceInfo
 0x89F8A567 cellImeJpGetConfirmYomiString
@@ -7512,36 +7512,36 @@
 0xB66B5308 sceSystemFileGetIndex
 0xF5BEE8C4 sceNpMatching2GetLobbyMemberIdListLocalVsh
 0x9C8D34DC InputDevice_Ps3Pad_SetFilterHandler
-0x5DD71B31 _ZN3vsh10OptionMenu8GetLevelEv
+0x5DD71B31 vsh::OptionMenu::GetLevel()
 0x473CD9F1 cellHttpClientSetRedirectCallback
 0xF409024E cellCryptoPuRsasp12048CRT
 0x6D2D9339 cellSpursEventFlagTryWait
-0x1474AC53 _ZNKSt7num_getIwSt19istreambuf_iteratorIwSt11char_traitsIwEEE6do_getES3_S3_RSt8ios_baseRNSt5_IosbIiE8_IostateERt
+0x1474AC53 std::num_get<wchar_t, std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>>::do_get(std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>, std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>, std::ios_base&, std::_Iosb<int>::_Iostate&, unsigned short&) const
 0xE89071AD isalpha_ascii
 0x1DA890C7 _cellSpursJobQueuePushAndReleaseJobBody
 0xA12FF4C6 sceNpGetNpIdByPsHandle
 0x94F52C91 cellAsfParser2AStdReadUChar8
 0x56584B4C at3enc_query_work_memory_bytes
 0xFE7AEFB7 SSL_CTX_use_certificate
-0xC5977986 _ZNSt8ios_base7_AddstdEv
+0xC5977986 std::ios_base::_Addstd()
 0x19CCBB81 mktime
 0xADDCE673 erfcl
 0x39BF419C valloc
 0x25B980A0 cellSailComposerReleaseEsUserAu
 0x6A24CC70 cellVideoExportInitialize
 0x15A11D97 FTC_SBitCache_New
-0x33E04D8E _ZNKSt7collateIwE12do_transformEPKwS2_
+0x33E04D8E std::collate<wchar_t>::do_transform(wchar_t const*, wchar_t const*) const
 0x7555DAFB cellM4hdEncOpenEx
 0xA0D463C0 UCS2toGBK
 0xB3C52B97 divx311DecReleasePicture
 0x520FF627 mios2_Client_VirtualCreate
 0x53E57474 cellFsUtilForceUmount
 0xA5362E73 cellSyncQueueClear
-0xF51DC289 _ZNSt7codecvtIccSt9_MbstatetED1Ev
+0xF51DC289 std::codecvt<char, char, std::_Mbstatet>::~codecvt()
 0xD053F113 sceNpBasicGetCustomInvitationEntry
 0x064A1816 rafUpdate
-0x8C6B8D39 _ZNSt13basic_filebufIcSt11char_traitsIcEED1Ev
-0xEB7D2C26 _ZN3paf8SyncCall5CheckEv
+0x8C6B8D39 std::basic_filebuf<char, std::char_traits<char>>::~basic_filebuf()
+0xEB7D2C26 paf::SyncCall::Check()
 0xE3769B4A smvd4GetExistenceFlag
 0x02466FE1 cellVoiceReduceSystemOverhead
 0x3ACC118E cellMicReadAux
@@ -7563,7 +7563,7 @@
 0x3741ECC7 sceNpTrophyDestroyContext
 0xD2A99B1E isprint
 0x9DFDAD46 cellAudioOutUnregisterCallback
-0x6463D9EA _ZNKSt8messagesIwE6do_getEiiiRKSbIwSt11char_traitsIwESaIwEE
+0x6463D9EA std::messages<wchar_t>::do_get(int, int, int, std::basic_string<wchar_t, std::char_traits<wchar_t>, std::allocator<wchar_t>> const&) const
 0x596DF41C UCS2toSJIS
 0x9D14DC46 ToSjisKata
 0x08CBD8E1 cellPhotoExportInitialize2
@@ -7578,7 +7578,7 @@
 0x088100F8 cellFt2dRotation
 0xC3610DBD cellMicSysShareOpen
 0x18E4FC82 cellAvsetGetHDMIKSVList
-0x35F7ED00 _ZN8cxmlutil7SetFileERKN4cxml7ElementEPKcRKNS0_4FileE
+0x35F7ED00 cxmlutil::SetFile(cxml::Element const&, char const*, cxml::File const&)
 0xA34FA0EB EUCJPstoJISs
 0xE20D7343 cellGcmSetWriteTextureLabel
 0xA4ED7DFE cellSaveDataDelete
@@ -7588,13 +7588,13 @@
 0x802A1BE8 cellMarlinDRMInit
 0xF1219EF4 cellMarlinDRMcencParsePsshBox
 0x3F701E78 _Poly
-0xC84FD77B _ZN3paf8PhXmItem10WidgetTypeEv
+0xC84FD77B paf::PhXmItem::WidgetType()
 0xA885CC9B cellFontOpenFontset
 0x97619DB5 cellDtcpIpCloseContent
 0x14619D58 cellGcmSetVertexProgramRegisterCount
 0xA526538D cellGcmSetVertexData2s
 0x1860F909 sys_dbg_get_spu_thread_ids
-0x31B18521 _ZN4xMMS13GetFieldIdForEPKhPjP15eMmsDbFieldTypePiPb
+0x31B18521 xMMS::GetFieldIdFor(unsigned char const*, unsigned int*, eMmsDbFieldType*, int*, bool*)
 0x1A324E03 cellVideoOutSetCopyControl
 0x1130EBE7 FTFaceH_SetRenderEffectSlant
 0x8B8231E5 cellPadLddGetPortNo
@@ -7602,7 +7602,7 @@
 0x84FCD5A6 sceNpDeleteCallback
 0xA5A863FE sceNpCommerce2SetBGDLAvailability
 0x4B584841 f_asinf
-0x901204F9 _ZN3paf5PhWeb9UISession5replyEPKwi
+0x901204F9 paf::PhWeb::UISession::reply(wchar_t const*, int)
 0x6BC46AAB cellMicReset
 0xC0E39B97 cellSsAimIsDEHA
 0xC85C4DE7 cellFsWidgetUnlink
@@ -7611,7 +7611,7 @@
 0x6CCAAE48 SSLCERT_get_pubkey
 0x0F48562D cellSsAimIsCEX
 0xC0609820 nearbyintf
-0x6E4A84C1 _ZNSt5ctypeIcED1Ev
+0x6E4A84C1 std::ctype<char>::~ctype()
 0x250C386C cellHttpInit
 0x4CEB9694 cellSpursGetJobChainInfo
 0x9C15FD4F cellCryptoPuTdesCbcCfb64Encrypt
@@ -7626,7 +7626,7 @@
 0x7B7A687A _WPutfld
 0xD48EAAE1 scalblnl
 0x3C616743 _LDtest
-0xD477DB73 _ZN3paf10HeapMemory8DumpInfoEi
+0xD477DB73 paf::HeapMemory::DumpInfo(int)
 0x91D59F69 cellFsGetPath
 0x6B660894 _acosf4fast
 0xA5F85E4D cellKbSetCodeType
@@ -7635,16 +7635,16 @@
 0x7E6FB08D _sys_net_lib_thread_exit
 0x1CF82D42 _QN4cell5Daisy4Lock7popOpenEv
 0xA69C749C cellSync2MutexTryLock
-0x3783ACFA _ZTv0_n12_NSt13basic_istreamIwSt11char_traitsIwEED1Ev
-0xF1C86C92 _ZNKSt12out_of_range8_DoraiseEv
+0x3783ACFA virtual thunk to std::basic_istream<wchar_t, std::char_traits<wchar_t>>::~basic_istream()
+0xF1C86C92 std::out_of_range::_Doraise() const
 0x411434BB asinf
-0xF7630798 _ZN3paf10PhInfoList10WidgetTypeEv
+0xF7630798 paf::PhInfoList::WidgetType()
 0xD7AA552E sceNpAuthCreateOAuthRequest
 0x54AC3519 cellVoiceGetPortInfo
 0x9874020D sjis2eucjp
 0x17001000 cellSpursAddUrgentCommand
 0x329DAD93 FTManager_OpenStreamFace
-0x46034D2E _ZNSt7num_putIcSt19ostreambuf_iteratorIcSt11char_traitsIcEEED0Ev
+0x46034D2E std::num_put<char, std::ostreambuf_iterator<char, std::char_traits<char>>>::~num_put()
 0xAFF080A4 sys_ppu_thread_exit
 0x7441419B svc1dGetSideInfoPic
 0x9121C0C6 cellSsUmReleaseBuffer
@@ -7652,31 +7652,31 @@
 0x2E34FF61 pafGuMuteDisplay
 0x18C23BDF FT_Outline_Get_Bitmap
 0x4654188A cellDtcpIpOpenEx
-0xFFF6EF55 _ZNKSt7num_getIwSt19istreambuf_iteratorIwSt11char_traitsIwEEE6do_getES3_S3_RSt8ios_baseRNSt5_IosbIiE8_IostateERb
-0x643235CF _ZNSt9strstreamD1Ev
+0xFFF6EF55 std::num_get<wchar_t, std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>>::do_get(std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>, std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>, std::ios_base&, std::_Iosb<int>::_Iostate&, bool&) const
+0x643235CF std::strstream::~strstream()
 0x1ABD0985 div
 0x40868AF4 cellPostNrOpen
 0x69106FD2 _init_by_array_TT800
 0xFF7A7BD2 cellSpursJobQueueOpen
-0x36E7826A _ZNSt7collateIcED1Ev
+0x36E7826A std::collate<char>::~collate()
 0x9A219C98 cellDtcpIpMoveCommitment
 0x1F71ECBE cellKbGetConfiguration
 0xF73FAA25 FTC_SBit_Cache_Lookup
 0x0ED9FAD9 mios2_Client_SendAsync
 0xD20F6601 independent_calloc
 0x129922A0 cellRescResetFlipStatus
-0x4DAEF6BE _ZN3paf8PhXmList14ChangeListModeEii
+0x4DAEF6BE paf::PhXmList::ChangeListMode(int, int)
 0x8E01379E cacoshf
 0xAEDE4B03 _sys_heap_delete_heap
 0x33DDD3AE cellGcmSetColorMaskMrt
 0x73E06F91 cellSpursLFQueueDetachLv2EventQueue
-0x0C74837D _ZN3paf7SurfaceC1EPNS_11SurfacePoolEii9ImageMode10ImageOrderbii
+0x0C74837D paf::Surface::Surface(paf::SurfacePool*, int, int, ImageMode, ImageOrder, bool, int, int)
 0x54F57626 rewind
 0x81F33783 cellFsStReadPutCurrentAddr
 0x154430FC xSettingSoundGetInterface
 0x818DCC19 xRegistryTransactionBegin
 0xF2BBBEE9 _Litob
-0x9AA7A8B3 _ZNSt10istrstreamD2Ev
+0x9AA7A8B3 std::istrstream::~istrstream()
 0x420DE176 FT_Glyph_Copy
 0xB602E328 cellCameraGetExtensionUnit
 0x8CA53DDE cellCameraIsAvailable
@@ -7689,7 +7689,7 @@
 0x2F280883 cellSysutilAvc2EstimateMemoryContainerSize
 0x54F2A4DE cellHttpRequestSetHeader
 0x8BA9AE83 cellTiffDecClose
-0xC499E073 _ZN3vsh10OptionMenu5CloseEPN3paf4ViewEPKcS5_
+0xC499E073 vsh::OptionMenu::Close(paf::View*, char const*, char const*)
 0x0A373522 cellPrintSendBand
 0x3E96C348 cellMarlinDRMActionCheck
 0x358D7F93 _f_lrintf
@@ -7705,21 +7705,21 @@
 0x29D5C6A4 cellSysutilAvcExtStartCameraDetection
 0x76948BFC cellSysconfAbort
 0xEE0CC40C _sceNpSysutilClientMalloc
-0x45F7D5ED _ZN3paf15CriticalSection5EnterEv
+0x45F7D5ED paf::CriticalSection::Enter()
 0x943231D1 _sce_net_set_name_server
-0xE861FA35 _ZN3paf7Surface10AttachCLUTERKNS_12SurfaceRCPtrINS_11SurfaceCLUTEEE
-0xAB5832FD _ZNSt10money_baseD1Ev
-0xAD382A99 _ZdlPvRKSt9nothrow_t
+0xE861FA35 paf::Surface::AttachCLUT(paf::SurfaceRCPtr<paf::SurfaceCLUT> const&)
+0xAB5832FD std::money_base::~money_base()
+0xAD382A99 operator delete(void*, std::nothrow_t const&)
 0x2D77FE17 _cellSync2SemaphoreAttributeInitialize
-0x1851C6A6 _ZN3vsh13MessageDialog20ResetDialogCloseTimeEv
-0xEE7108A5 _ZN3paf9PhNumSpin8SetStyleEib
+0x1851C6A6 vsh::MessageDialog::ResetDialogCloseTime()
+0xEE7108A5 paf::PhNumSpin::SetStyle(int, bool)
 0x1DCD8609 _Strxfrmx
 0x6D704447 atxenc_get_nbytes
 0x4AC76585 cellRecClose
 0x59BBEBD4 cellGameGetHomePath
-0x70FEA77E _ZN9PSJSValueaSEP13PSJSValueImpl
+0x70FEA77E PSJSValue::operator= (PSJSValueImpl*)
 0x8D3F8D49 sceNpMatching2SignalingGetPingInfo
-0xA3F5C3B2 _ZNSt9strstreamD2Ev
+0xA3F5C3B2 std::strstream::~strstream()
 0x734CA589 _f_cosf
 0x9069BDBB sjvtdFlushPicture
 0x97B2DA6A cellSysutilAvc2LeaveChatRequest
@@ -7729,33 +7729,33 @@
 0x6687FBA4 _Fgpos
 0xE3D2DEEE sceNpMatching2LeaveLobbyVsh
 0xF1D3552D cellSpursReadyCountCompareAndSwap
-0xAACB825F _ZNK3paf10PhSaveData12GetFrameRateEv
-0x1C8083C5 _ZNSt12strstreambufD0Ev
+0xAACB825F paf::PhSaveData::GetFrameRate() const
+0x1C8083C5 std::strstreambuf::~strstreambuf()
 0xC708618A cellM4vEncGetLocalDecodedFrame
 0x43B989F5 sceNpBasicSendMessageAttachment
 0x94034C95 cellSpursTasksetUnsetExceptionEventHandler
 0x6F8FD267 sceNpMatchingSetRoomInfo
 0x0CDD7A1C cellGcmSetLineWidth
 0xA6EB0B62 FT_Get_Kerning
-0x34EBB81E _ZN3paf11SurfacePool8AllocateEii
+0x34EBB81E paf::SurfacePool::Allocate(int, int)
 0x82054D11 _cellSslConvertSslVersion
-0x2FF8D101 _ZNSt6localeC1ERKS_S1_i
+0x2FF8D101 std::locale::locale(std::locale const&, std::locale const&, int)
 0x31B9397B cellAsfReadUChar8
 0x8809CDFD _Getpwctytab
-0x0E744EF5 _ZNSt9money_getIwSt19istreambuf_iteratorIwSt11char_traitsIwEEED1Ev
+0x0E744EF5 std::money_get<wchar_t, std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>>::~money_get()
 0x2707FD60 cellSailComposerReleaseEsAudioAu
 0xCCC66F11 _FSinh
-0x05FC94FF _ZN10PSJSObjectdlEPv
+0x05FC94FF PSJSObject::operator delete(void*)
 0xBB543189 cellRtcSetTime_t
 0x6D4ADC3B sceNpScoreGetClansMembersRankingByRange
-0x39775CE9 _ZNSt11logic_errorD2Ev
+0x39775CE9 std::logic_error::~logic_error()
 0x915455B3 cellSpursJobQueueSendSignal
-0x97911F5F _ZNSt15basic_streambufIcSt11char_traitsIcEE5uflowEv
+0x97911F5F std::basic_streambuf<char, std::char_traits<char>>::uflow()
 0x6BE01849 atx_get_encode_setting
 0x2E42F94A sceNpMatching2SignalingGetPeerNetInfoResult
 0x6FADEFAD smf_ApPs_GetTrackNum
 0xC81CCF8A cellSearchInitialize
-0x6574DEE6 _ZN29xMMSMdRelationResolveAccessor11GetInstanceEv
+0x6574DEE6 xMMSMdRelationResolveAccessor::GetInstance()
 0x96328741 _sys_process_at_Exitspawn
 0x4D5FAA76 cellGcmSetLineStippleEnable
 0xCF89F218 _cellSpursJobQueuePort2PushJobBody
@@ -7772,7 +7772,7 @@
 0x3C7189C0 _sys_net_lib_thread_create
 0x5C0C3486 cellJpgEncCoreWriteHeader
 0x6997E44A PAF_Resource_DOMGetNodeID
-0xE02A30D5 _ZN3paf14PhAppearXmItem20SetDefaultLabelColorERK4vec4
+0xE02A30D5 paf::PhAppearXmItem::SetDefaultLabelColor(vec4 const&)
 0x4914F70B Zi8AttachUWD
 0x122D3DB1 cellRtcAlarmRegister
 0x8451EDF0 sqrtf
@@ -7780,21 +7780,21 @@
 0xBC1D69C5 atoll
 0x89F6F026 time
 0x4E9BB95B cellBGDLGetInfo
-0x226FBD53 _ZN3paf8PhXmItem8IconMoveERK4vec4ffiii
+0x226FBD53 paf::PhXmItem::IconMove(vec4 const&, float, float, int, int, int)
 0x576E31A5 FT_Select_Size
 0xF885420C FT_Stroker_ConicTo
 0x662BD637 cellPngEncWaitForInput
 0x293D9E9C cellPrintCancelJob
 0x8BD1DEB2 _LTgamma
-0xED5FDE32 _ZN3paf8DateTime6FormatEPwjPKw
-0x02AB5840 _ZNK3paf6PhFont11GetCharInfoENS0_9GlyphTypeEtP18SceFont_t_charInfo
-0x7FF35597 _ZNSt9money_putIcSt19ostreambuf_iteratorIcSt11char_traitsIcEEE7_GetcatEPPKNSt6locale5facetE
+0xED5FDE32 paf::DateTime::Format(wchar_t*, unsigned int, wchar_t const*)
+0x02AB5840 paf::PhFont::GetCharInfo(paf::PhFont::GlyphType, unsigned short, SceFont_t_charInfo*) const
+0x7FF35597 std::money_put<char, std::ostreambuf_iterator<char, std::char_traits<char>>>::_Getcat(std::locale::facet const**)
 0x2DBC92C7 cellSysutilAvcShowPanel
 0xAF505DEF sceNpBasicGetMatchingInvitationEntryCount
 0x3D80F655 SSL_version
-0x5E0BDA86 _ZN10bXCeMemMgrD2Ev
+0x5E0BDA86 bXCeMemMgr::~bXCeMemMgr()
 0xA5DACF92 ERR_get_error
-0x6C386F54 _ZNSt15basic_streambufIcSt11char_traitsIcEE7seekposESt4fposISt9_MbstatetENSt5_IosbIiE9_OpenmodeE
+0x6C386F54 std::basic_streambuf<char, std::char_traits<char>>::seekpos(std::fpos<std::_Mbstatet>, std::_Iosb<int>::_Openmode)
 0x38B3CFEA ATEgetRegWordNum
 0x8B8A2F48 cellSaveDataUserFixedDelete
 0xD82B5FA4 _cellAudioStopRSX
@@ -7802,7 +7802,7 @@
 0x16FF9BA0 cellSysutilAvc2StartVoiceDetection
 0x0ADF8089 _cellAudioOutputBufferGetAddr
 0xEB9DF054 sceNpCommerceGetCategoryInfo
-0x6964C72A _ZN3paf8PhXmList8IconMoveEiRK4vec4ffbiii
+0x6964C72A paf::PhXmList::IconMove(int, vec4 const&, float, float, bool, int, int, int)
 0xEC969F67 sceNpC7yLookupDestroyTransactionVsh
 0x496CFCD0 cellPngEncQueryAttr
 0x63468A88 sceNetFreeVsh
@@ -7815,87 +7815,87 @@
 0xEFEB2679 _cellSpursWorkloadAttributeInitialize
 0x0F19F1E0 smf_ApPl_GetSampleNoByTime
 0x4D915204 cellHttpClientSetCookieSendCallback
-0x4D930842 _ZN3paf10PhProgressC1EPNS_8PhWidgetEPNS_8PhAppearE
-0xED3DA02B _Znwjj
+0x4D930842 paf::PhProgress::PhProgress(paf::PhWidget*, paf::PhAppear*)
+0xED3DA02B operator new(unsigned int, unsigned int)
 0xF638C45E FTC_Manager_LookupSize
 0x56776C0D cellKey2CharGetChar
-0xBD01AEF9 _ZN3paf6PhText14ReleaseSurfaceEv
+0xBD01AEF9 paf::PhText::ReleaseSurface()
 0x1BA0444D sqlite3_value_type
 0xEF5A353D cellSaveDataListLoad
 0xB81B9777 cellSysutilAvc2EnumPlayers
-0xA5306EDB _ZNSt10moneypunctIwLb1EED1Ev
+0xA5306EDB std::moneypunct<wchar_t, true>::~moneypunct()
 0xEC2E26B6 cellPesmPrepareRec
 0x3DF65B64 eucjp2sjis
 0x93C523C6 cellWebBrowserConfigSetNotifyHook2
-0x4CB35E7D _ZNSt9time_baseD1Ev
+0x4CB35E7D std::time_base::~time_base()
 0x9A87BB3A _Getmbcurmax
 0xD8F3972D cellUsbdAllocateMemoryFromContainer
 0x9D0F4AF1 cellVoiceSetPortAttr
 0xB88738E3 cellGcmSysSetIdSys
-0x5438D7D8 _ZdaPvS_
+0x5438D7D8 operator delete[](void*, void*)
 0x218372FB scePS2McIconSys_GetLightColor2
-0x332B4874 _Z30x3USBMass_GetAttachedDeviceIdsPPyPi
+0x332B4874 x3USBMass_GetAttachedDeviceIds(unsigned long long**, int*)
 0x2C5B7FC9 sceNpMatching2GetRoomMemberDataExternalList
 0xF11FE0F1 cellSpursJobQueuePort2Create
 0xEC6FC2CC sceNpAddCallback
 0xA547ADDE cellGcmGetControlRegister
 0xCC5E0C72 _divi4
-0x654B91B5 _Z15pafGumPopMatrixv
+0x654B91B5 pafGumPopMatrix()
 0xFCEDABC3 _fmodf4
 0xED73D859 cellAvcEncSmallCancelAuInfo
 0x22C3E308 _exp2f4
 0x82CED772 cellSysutilAvc2GetWindowShowStatus
-0x7FD1B82B _ZN10bXCeXMLToD7DestroyEv
+0x7FD1B82B bXCeXMLToD::Destroy()
 0x825B730A smf_ApPs_GetDataRefLocStrLen
-0xCA16B292 _ZmLR4mat4RKS_
+0xCA16B292 operator*= (mat4&, mat4 const&)
 0x10D0D7FC cellHttpResponseGetStatusCode
 0x58FF49AC dlnaPrintStartPage
 0x3A20BC34 UCS2stoMSJISs
 0xB89863BC _rsqrtf4fast
 0x65FE1C86 cellExifOpenTiffFile
-0xA286B24A _ZN4cell5Daisy15LFQueue2PopOpenEPNS0_8LFQueue2E
+0xA286B24A cell::Daisy::LFQueue2PopOpen(cell::Daisy::LFQueue2*)
 0x8B0BC111 cellSsVtrmFree2
 0x1E909446 sceNpInstallerExecVideoDownload
 0x4AE98BFC rafExit
 0x0C90E37C cellDSEEGetHandle
 0x8BD01379 cellDtcpIpOpen
-0x316C9286 _ZN7bXUtils7bXToXMLEPK7bXCeDocPPcPjb
+0x316C9286 bXUtils::bXToXML(bXCeDoc const*, char**, unsigned int*, bool)
 0x5FB9B05D cellSpursJobQueueAttributeSetMaxGrab
 0xDBDC6E45 sqlite3_column_name16
 0x0B2218A3 sceNpMatching2GetLobbyMemberDataInternalList
 0x271A0B06 cellHttpClientGetSendTimeout
-0xBC91AEB3 _ZN3paf7Surface12RenderTargetEv
+0xBC91AEB3 paf::Surface::RenderTarget()
 0x5C74903D cellFsReaddir
 0x214FE115 ft_lzwstate_reset
 0x88F03575 setsockopt
 0x99EFE171 cellAtracIsSecondBufferNeeded
 0xB995662E sys_raw_spu_image_load
 0xF9677A46 cellFontInitLibraryFreeType
-0x796A32FE _ZN3paf8PhXmList13GetItemWidgetEi
+0x796A32FE paf::PhXmList::GetItemWidget(int)
 0x4931B44E UTF8toMSJIS
 0x3E7EB58F frexpf4
-0xD38F4018 _ZSt11_MaklocbyteIwEcT_RKSt7_Cvtvec
+0xD38F4018 char std::_Maklocbyte<wchar_t>(wchar_t, std::_Cvtvec const&)
 0x749C9B5F cellWebBrowserInitialize
 0x1197B52C sceNpTrophyRegisterContext
 0x1AC0D23D L10nConvert
 0x1F913E8D chmod
 0x2C43AB76 cellPesmOpenDevice
 0xBD42DA64 cellGcmSetTransferScaleSurface
-0xF73F6AFC _ZNSt13basic_filebufIcSt11char_traitsIcEE7seekoffElNSt5_IosbIiE8_SeekdirENS4_9_OpenmodeE
+0xF73F6AFC std::basic_filebuf<char, std::char_traits<char>>::seekoff(long, std::_Iosb<int>::_Seekdir, std::_Iosb<int>::_Openmode)
 0x7B249315 cellUsbPspcmPollRecvAsync
-0x14CF6448 _ZN3paf8PhXmList9ShowItemsEff
+0x14CF6448 paf::PhXmList::ShowItems(float, float)
 0x4F4EEE83 svc1dDecodePicture2
 0xD70DF92A _FCaddcr
 0x6EF5D792 FT_Outline_Translate
 0xA2E6C4B0 _QN4cell5Daisy17LFQueue2PushCloseEPNS0_8LFQueue2EPFiPvjE
 0xF6F5FBCA cellKeySheapBarrierDelete
-0x9B3D45E9 _ZN13PSJSValueImpl11NewFromPoolERK11PSJSContextf
+0x9B3D45E9 PSJSValueImpl::NewFromPool(PSJSContext const&, float)
 0x0F67C877 sceNpC7yScoreRecordGameDataRequestVsh
 0xBDC49BC1 cellGcmSetPerfMonPushMarker
 0xD8AF2727 PhiUpdateDisplay_platform
 0x0BC386C8 ToSjisLower
 0x4262E880 cellJpgEncGetStreamInfo
-0x6BA1D72F _ZN4cxml8Document13CreateElementEPKciPNS_7ElementE
+0x6BA1D72F cxml::Document::CreateElement(char const*, int, cxml::Element*)
 0x59640BC6 raw_spu_read_ullong
 0xF283C143 sceNpDrmExecuteGamePurchase
 0xA5A86557 sys_net_get_test_param
@@ -7906,23 +7906,23 @@
 0x83BC6489 cellAvcEncSmallQueryResource
 0x84F154B2 cellMusicDecodeInitializeSystemWorkload
 0x67555D2A sjvtdGetSideInfoSeq
-0xE8C15F8A _ZNSt7_MpunctIwED2Ev
+0xE8C15F8A std::_Mpunct<wchar_t>::~_Mpunct()
 0x0247C69E cellSailGraphicsAdapterGetFrame
-0xBB712718 _ZnwjRKSt9nothrow_t
+0xBB712718 operator new(unsigned int, std::nothrow_t const&)
 0xF9EC2DB6 getpeername
 0xAD7D8F38 cellPhotoDecodeFinalize
 0xE90EFFEA cellMusicExportFinalize
 0x3F2B82DF FT_Outline_Done
 0xFEE33481 cellGemGetStatusFlags
 0x3172759D sys_game_get_temperature
-0x2689337F _ZN3paf8PhXmList8IconSizeEiRK4vec4ffiii
+0x2689337F paf::PhXmList::IconSize(int, vec4 const&, float, float, int, int, int)
 0xA566693D cellGcmCgGetNamedParameter
-0x17BA161B _ZN4xMMS15GetValuePointerEPvjPS0_
+0x17BA161B xMMS::GetValuePointer(void*, unsigned int, void**)
 0x2C45FE6A fmaxl
-0xBC6E66D6 _ZN4mat4aSEf
+0xBC6E66D6 mat4::operator= (float)
 0xE2434507 sys_net_set_netemu_test_param
 0xE0F90E44 sceNpCommerce2InitGetProductInfoListResult
-0x54CC1C3F _ZNK4cxml7Element13GetFirstChildEv
+0x54CC1C3F cxml::Element::GetFirstChild() const
 0xD97CE5D4 fesetround
 0xCCC891CA cellFt2dHistogram
 0x3897F229 cellFontControl
@@ -7930,36 +7930,36 @@
 0xE6D4202F cellHttpsEnd
 0x54D414BE cellAsfParser2AStdReadData
 0x5D7BDBEA cellCryptoPuRsaep512
-0x44CDAE21 _ZNK3paf8PhWidget12GetLayoutPosERiS1_S1_R4vec4
+0x44CDAE21 paf::PhWidget::GetLayoutPos(int&, int&, int&, vec4&) const
 0x27B5EF53 smf_ApPs_GetTrackPresentationType
-0x5837B7E2 _ZN3paf7PhXmBar16SetTopLabelAlphaEfff
+0x5837B7E2 paf::PhXmBar::SetTopLabelAlpha(float, float, float)
 0xA58DF87F cellSyncQueueTryPop
 0x53558B6B UTF16stoUCS2s
 0x9A72059D EUCKRtoUCS2
 0x8644EEA8 PAF_Resource_ResolveRefString
 0xBF9B2B61 cellAvcEncSmallReleaseLocalDecodedFrame
 0xAD5D3E57 _FLgamma
-0xF15A0DE5 _ZN3paf6PhSpin10SetTextureERKNS_12SurfaceRCPtrINS_7SurfaceEEEi
+0xF15A0DE5 paf::PhSpin::SetTexture(paf::SurfaceRCPtr<paf::Surface> const&, int)
 0xBC374779 _Getlname
 0xC04E2438 cellFiberPpuUtilWorkerControlShutdown
 0xD8D157F5 f_expf
-0x2030C3B9 _ZN3paf6PhSpin8SetFocusEPNS_7PhEventEj
+0x2030C3B9 paf::PhSpin::SetFocus(paf::PhEvent*, unsigned int)
 0xCC20195F FT_New_Face
-0xC0C4E042 _ZN3vsh3fim15setGamePresenceEPK17SceNetXmppPayload
+0xC0C4E042 vsh::fim::setGamePresence(SceNetXmppPayload const*)
 0xD3039D4D _sys_strncpy
 0xB642C61A Zi8DetachPUD
-0x5E1BEA06 _ZN3paf10PhSaveData16SetLightPositionEiRK4vec4
+0x5E1BEA06 paf::PhSaveData::SetLightPosition(int, vec4 const&)
 0x13563C45 sceNpMatching2CreateServerContextVsh
 0x0618936B _sys_vsnprintf
-0x25B8BD56 _Z27_sce_np_sysutil_send_packetiRN4cxml8DocumentE
-0xC69ECA71 _ZN3paf5ImageD1Ev
+0x25B8BD56 _sce_np_sysutil_send_packet(int, cxml::Document&)
+0xC69ECA71 paf::Image::~Image()
 0x336B4191 _Getint
 0x13AE18F3 cellSpursTaskExitCodeGet
 0x0D896B97 cellHttpSetProxy
-0xD11A3565 _ZN3paf11PhLabelText15SetShadowRenderEPNS_9PhSRenderE
-0x6C19DB26 _ZNKSt7_MpunctIcE16do_thousands_sepEv
+0xD11A3565 paf::PhLabelText::SetShadowRender(paf::PhSRender*)
+0x6C19DB26 std::_Mpunct<char>::do_thousands_sep() const
 0x0B6CCC14 cellMgVideoEncryptSample
-0xEB73AD01 _ZN3paf6PhText12SetFontStyleERKNS_11PhFontStyleE
+0xEB73AD01 paf::PhText::SetFontStyle(paf::PhFontStyle const&)
 0x36778D1B coshf
 0xBCFECDAE cellGcmGetVBlankCount2
 0xA8615DC8 cellMusicDecodeFinalize
@@ -7968,10 +7968,10 @@
 0xD8270894 fdim
 0xBD5B10C7 Zi8ConvertUC2Key
 0x1A1ADEDE rsqrtf4fast
-0x1A6BEE58 _ZN13bXCeXMLParser5ParseEPKcib
+0x1A6BEE58 bXCeXMLParser::Parse(char const*, int, bool)
 0x549F260D sjvtdDiscontinue
-0x696B71F4 _ZN3paf15SaveDataPointee7ReleaseEv
-0x8E3A093F _ZNK9PSJSValue8ToNumberERK11PSJSContext
+0x696B71F4 paf::SaveDataPointee::Release()
+0x8E3A093F PSJSValue::ToNumber(PSJSContext const&) const
 0xE0443A44 cellMusicExportInitialize2
 0xE27B3C01 sce_paf_private_malloc
 0x1E989496 cellSearchGetContentInfoSharable
@@ -7982,7 +7982,7 @@
 0xA3440924 closedir
 0xE106CB7B smf_ApPs_GetVideoProfileInfo
 0xB4FA3111 cellHttpInitCache
-0x61248C80 _ZNKSt8time_getIwSt19istreambuf_iteratorIwSt11char_traitsIwEEE13do_date_orderEv
+0x61248C80 std::time_get<wchar_t, std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>>::do_date_order() const
 0x99406D0B cellFsChmod
 0x51BC81E8 cellMp3EncStartSeq
 0x3A66FDB8 cellGcmSetVertexDataScaled4s
@@ -7991,60 +7991,60 @@
 0x13268E21 FT_Bitmap_New
 0xFF299E03 sceNpTrophyGetGameIcon
 0x5267175E avcDecGetVersion
-0x903AFA37 _ZTv0_n12_NSt13basic_ostreamIwSt11char_traitsIwEED0Ev
+0x903AFA37 virtual thunk to std::basic_ostream<wchar_t, std::char_traits<wchar_t>>::~basic_ostream()
 0x572A4D1D sceNpCommerceSetDataFlagStartVsh
 0xD9C9F093 FT_Stroker_New
 0x2AB21EA9 sceNpTusGetMultiSlotDataStatusVUserAsync
 0x43775F53 Zi8AddUsedWordW
 0x6E0705C4 UTF8toEUCJP
 0x9A7A71B5 FT_Get_WinFNT_Header
-0x23CCCCBB _ZN3paf13PhAppearPlane8SetStyleEii
+0x23CCCCBB paf::PhAppearPlane::SetStyle(int, int)
 0x14D6C1E3 cellGcmCgGetInstructionSlot
-0x4EABD9DE _ZN3paf7Surface4LockEi
+0x4EABD9DE paf::Surface::Lock(int)
 0x7BF2B5F7 sceNpMatching2GetUserInfoListVsh
 0x7BC2C8A8 cellMsgDialogProgressBarReset
 0x84E4A0A0 cellHidReleaseOwnership
 0xF1A9AF6F avcDecAccessUnit
-0x59C77266 _ZNKSt7num_getIwSt19istreambuf_iteratorIwSt11char_traitsIwEEE6do_getES3_S3_RSt8ios_baseRNSt5_IosbIiE8_IostateERd
-0x9587CF7C _ZN11xCBInstance14InsertMetaDataEP10_xCB_TablePvPx
+0x59C77266 std::num_get<wchar_t, std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>>::do_get(std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>, std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>, std::ios_base&, std::_Iosb<int>::_Iostate&, double&) const
+0x9587CF7C xCBInstance::InsertMetaData(_xCB_Table*, void*, long long*)
 0xECE75E73 sceNetStunInit
 0x3773692F cellCelpEncGetAu
 0xDD872661 FT_Stream_EnterFrame
 0x6674DE2D cellMusicGetContentsId2
-0x476B2221 _ZN24xMMSMdGeneratorRequester11GetInstanceEv
+0x476B2221 xMMSMdGeneratorRequester::GetInstance()
 0x39A69619 sceNpCommerceGetSkuId
 0xE391F8EA cellCryptoPuRsavp12048
 0x70E319B5 cellSysmoduleIsLoadedEx
 0x459072C3 _init_TT800
 0x5E48DEDE exp2f4
 0x742CEC0D cellSpursJobQueueAttributeSetIsJobTypeMemoryCheck
-0xFEB4107C _ZNSt12codecvt_baseD2Ev
-0x2356EF16 _ZnajRKSt9nothrow_t
+0xFEB4107C std::codecvt_base::~codecvt_base()
+0x2356EF16 operator new[](unsigned int, std::nothrow_t const&)
 0xEA58B5D3 smf_ApPs_GetCttsBoxAvailability
 0x9DAFC0D9 cellRtcGetCurrentTick
 0x0B3F4E90 catanhf
 0x07EE139A cellVideoPlayerOpenFileId
-0x88DB3841 _ZN3paf10PhMenuList14SetSelectedPosEi
+0x88DB3841 paf::PhMenuList::SetSelectedPos(int)
 0x89D1D168 _LAtan
-0x18628537 _ZNKSt8numpunctIcE16do_decimal_pointEv
+0x18628537 std::numpunct<char>::do_decimal_point() const
 0x16698E83 cellVdecClose
 0x418BDFE1 _get_fd
 0xE469FB20 _Atexit
 0xB4C43B98 cellMtpRecvEvent
 0x71F2BC56 _divf4fast
-0x878B5986 _ZN13MmsMdAccessor11GetInstanceEv
+0x878B5986 MmsMdAccessor::GetInstance()
 0x4CE8E544 Heap_Alloc
 0xA931356E cellMinisSaveDataListAutoSave
 0xF7501C3F sceNpUtilParseTitleId
 0x5FD43FE4 cellSpursWaitForWorkloadShutdown
-0x295A7374 _ZN3paf7PhMiconD1Ev
+0x295A7374 paf::PhMicon::~PhMicon()
 0xDBF4C59C cellPadGetCapabilityInfo
 0x1DA42D70 eucjphan2zen
 0xF5EF229C _Getpwcostate
 0x33CB6159 cellSslGetMemoryInfo
 0x53764725 UCS2stoGB18030s
 0x5E06C3FE __getpid
-0xFDD0EB53 _ZN3paf11PhLabelText14ReleaseSurfaceEj
+0xFDD0EB53 paf::PhLabelText::ReleaseSurface(unsigned int)
 0xC457B203 cellSailSourceNotifyCloseCompleted
 0x14348B57 divi4
 0x273D116A cellSaveDataUserListExport
@@ -8053,31 +8053,31 @@
 0x580F8203 sys_dbg_vm_get_page_information
 0x3BE4620C cellM4vEncCancelFrame
 0x8FD1D549 sceNpSnsFbCreateHandle
-0x8BC095CF _ZN3paf10MessageBox26SetQueryTextureInfoHandlerEPFbNS0_11TextureTypeEPNS0_11TextureInfoEE
-0xAA422FCB _ZN3paf4CondC1ERNS_5MutexEPKc
+0x8BC095CF paf::MessageBox::SetQueryTextureInfoHandler(bool (*)(paf::MessageBox::TextureType, paf::MessageBox::TextureInfo*))
+0xAA422FCB paf::Cond::Cond(paf::Mutex&, char const*)
 0xE25F7DDA cellAvcEncGetFrameForInput
-0xF4FA6F28 _ZN7bXCeDoc7AddAttrEP8bXCeNodePcS2_i
+0xF4FA6F28 bXCeDoc::AddAttr(bXCeNode*, char*, char*, int)
 0xD14ECE90 strtol
 0x4C0765CD sceNpMatching2SetUserInfoVsh
 0xEDCDED77 cellCryptoPuRsaesPkcs1v15Enc2048
-0x0BF9DC65 _Z24xcbGetTargetMetadataTypePvPPh
+0x0BF9DC65 xcbGetTargetMetadataType(void*, unsigned char**)
 0x7CB33C2E cellSpursTaskGetReadOnlyAreaPattern
 0xE62A0E88 sceNpSignalingCreateCtxVsh
 0xC3E29E69 _QN4cell5Daisy4Lock18getNextHeadPointerEv
 0xAC5BA03A cellMicGetSignalAttr
-0x0793CAA0 _ZNK7bXCeDoc11GetNextAttrEP8bXCeNode
-0x3FC2324D _ZNKSt7num_putIcSt19ostreambuf_iteratorIcSt11char_traitsIcEEE6do_putES3_RSt8ios_basecd
+0x0793CAA0 bXCeDoc::GetNextAttr(bXCeNode*) const
+0x3FC2324D std::num_put<char, std::ostreambuf_iterator<char, std::char_traits<char>>>::do_put(std::ostreambuf_iterator<char, std::char_traits<char>>, std::ios_base&, char, double) const
 0x42C716B5 cellDmuxGetAu
 0xC2261290 FT_Bitmap_Done
 0x1373C94D cellGcmCgSetInstructionSlot
 0xFADE48B2 cellRudpProcessEvents
 0x78D7F9AD sceNpCommerceGetSkuPrice
-0xCD75BA15 _ZN11xCBInstance27GetMetadataGenerationConfigEv
+0xCD75BA15 xCBInstance::GetMetadataGenerationConfig()
 0x9C8D3FF7 cellFontGlyphGetOutlineVertexes
 0xD61B5EFC pafGuCgSetVertexShader
 0xE7951DEE cellGameDataCheckCreate
 0x72CC6CF7 cellGameGetHomeDataImportPath
-0xD1B181E0 _ZN3paf5Image7SetClipERKNS_9ImageRectE
+0xD1B181E0 paf::Image::SetClip(paf::ImageRect const&)
 0x15934401 cellSpursJobQueueGetSuspendedJobSize
 0xA85A4951 sceNpCommerceGetSkuDescription
 0x29020E75 FT_Stream_Free
@@ -8087,29 +8087,29 @@
 0x02D834DA dlnaPrintSetPrinter
 0x6D3BB15B cellFsSdataOpenByFd
 0x1139A206 cellSailPlayerSetSoundAdapter
-0x3F6A6E68 _ZNSt13basic_filebufIcSt11char_traitsIcEE9_EndwriteEv
-0x538E485C _ZN3paf5Sound6Output18GetNumberOfDevicesEj
+0x3F6A6E68 std::basic_filebuf<char, std::char_traits<char>>::_Endwrite()
+0x538E485C paf::Sound::Output::GetNumberOfDevices(unsigned int)
 0x10CABEFF cellWebBrowserGetUsrdataOnGameExit
 0xB90AE607 FTRenderBuf_End
 0xA2945229 _WGetint
-0xE5B6AF9E _ZNK3paf4View8ArgumentcviEv
-0x4EF0EB8E _ZNSt12strstreambuf7seekoffElNSt5_IosbIiE8_SeekdirENS1_9_OpenmodeE
-0xFE468B7A _ZTv0_n12_NSdD0Ev
+0xE5B6AF9E paf::View::Argument::operator int() const
+0x4EF0EB8E std::strstreambuf::seekoff(long, std::_Iosb<int>::_Seekdir, std::_Iosb<int>::_Openmode)
+0xFE468B7A virtual thunk to std::basic_iostream<char, std::char_traits<char>>::~basic_iostream()
 0x4B1EE41D sceNetApCtlTermVsh
 0x2582FDE6 cellExifClose
 0xFDBF6AC5 UTF8stoUCS2s
 0x1249C1D1 cellHttpClientGetConnectionWaitTimeout
-0xC9142131 _ZN29xMMSMdRelationResolveAccessor11GetMetadataEyPPv
-0x40C4C4D9 _ZN3paf6PhFontC1Ev
+0xC9142131 xMMSMdRelationResolveAccessor::GetMetadata(unsigned long long, void**)
+0x40C4C4D9 paf::PhFont::PhFont()
 0xE75C40F2 sys_process_get_paramsfo
 0x5D473170 cellHttpClientSetKeepAlive
 0x2EB6EFEE cellCelp8EncOpen
 0xAD3A093D _LCosh
 0x2CBD9806 cellVdecGetPicItemExt
 0x964CD1B8 cellRecStart
-0x8BC523EB _ZN3paf4View16PlayAnimSequenceEPNS_8PhWidgetEPKc
+0x8BC523EB paf::View::PlayAnimSequence(paf::PhWidget*, char const*)
 0x38E69F09 pow
-0x41DF5D21 _ZN4cell5Daisy4Lock15completeProduceEj
+0x41DF5D21 cell::Daisy::Lock::completeProduce(unsigned int)
 0x329EC019 rsqrtf4
 0xB1840B53 cellFsSdataOpen
 0x62A015B6 cellGcmSetAntiAliasingControl
@@ -8119,41 +8119,41 @@
 0x99666F31 sceNpUtilGetEnv
 0x00FDE072 f_powf
 0xD058B6C2 cellGcmSetClearDepthStencil
-0x85BA32C4 _ZN3paf9PhNumSpin6CreateEiibiPPNS_7PhSTextEPKi
+0x85BA32C4 paf::PhNumSpin::Create(int, int, bool, int, paf::PhSText**, int const*)
 0x69725DCE lgamma
-0x7142AD20 _ZNKSt7_MpunctIcE16do_decimal_pointEv
+0x7142AD20 std::_Mpunct<char>::do_decimal_point() const
 0x22916F45 sys_dbg_register_ppu_exception_handler
 0xE14CA62D cellSpursCreateTask2
 0x57D3FF62 cellGcmSetInvalidateZcull
-0x0BECDA92 _ZN3vsh17FormatFreeSize_KBEPwij
-0xD8AEB94A _ZNSt8messagesIcED1Ev
+0x0BECDA92 vsh::FormatFreeSize_KB(wchar_t*, int, unsigned int)
+0xD8AEB94A std::messages<char>::~messages()
 0x65A86A64 cellDtcpIpGetHttpStatusCode
 0x218B64DA cellSslCertGetNotAfter
 0x37F42E67 FT_Get_Next_Char
 0x11385230 FT_Outline_New_Internal
-0x16FCC1BD _ZN4xMMS17GetNumberOfFieldsEPvPj
+0x16FCC1BD xMMS::GetNumberOfFields(void*, unsigned int*)
 0x9F67BFBD sceNpTusGetFriendsVariableAsync
 0x95665052 svc1dReleasePicture
 0x70ACEC67 cellGameContentPermit
 0xB20F87B3 sys_crash_dump_set_user_log_area
 0xF16D10CB cellVideoPlayerPlaybackControl
-0xD98B043A _ZN13bXCeUTF8Utils14GetNextIntegerEPiPcj
+0xD98B043A bXCeUTF8Utils::GetNextInteger(int*, char*, unsigned int)
 0x370136FE sceNpTrophyGetRequiredDiskSpace
 0x2ECD48ED sceNpDrmVerifyUpgradeLicense
 0x75F16DC5 cellFsSetIoBufferFromDefaultContainer
 0x634B1502 cellSpursJobQueuePortSync
-0xB5E55F6C _ZNK3paf7PhMicon11GetChannelsEv
+0xB5E55F6C paf::PhMicon::GetChannels() const
 0x4157B2E2 sceNpMatching2LeaveRoomVsh
 0x7961474B FTCacheBuffer_End
-0xBDA96809 _ZN3paf9PhNumSpinC1EPNS_8PhWidgetEPNS_8PhAppearE
+0xBDA96809 paf::PhNumSpin::PhNumSpin(paf::PhWidget*, paf::PhAppear*)
 0xE44874F3 cellGcmSysGetLastVBlankTime
 0xE55A4804 SSL_set_ssl_method
-0xF66AAF4B _ZN3Ime22OskReleaseInputContextEPNS_21InputContextInterfaceE
+0xF66AAF4B Ime::OskReleaseInputContext(Ime::InputContextInterface*)
 0x6BA92C44 SSL_CIPHER_description
-0x77479F6F _ZNK3paf6PhText13GetCurrentPosEv
-0x0E147A9D _ZNSt13basic_filebufIwSt11char_traitsIwEE9pbackfailEi
+0x77479F6F paf::PhText::GetCurrentPos() const
+0x0E147A9D std::basic_filebuf<wchar_t, std::char_traits<wchar_t>>::pbackfail(int)
 0x3436F008 csinhf
-0x70078E2D _ZNK3paf7PhMicon9IsEnabledEi
+0x70078E2D paf::PhMicon::IsEnabled(int) const
 0xED2CBC23 cellMarlinDLCheckActivationStatus
 0x8B72CDA1 cellPadGetData
 0xEC0A1FBF sceNpBasicSendMessage
@@ -8162,12 +8162,12 @@
 0x303C19CD cellSpursCreateJobChainWithAttribute
 0xC2D90EC9 cellSailMp4MovieGetTrackByTypeAndIndex
 0x82D5ECDF EucJpZen2Han
-0x118361B1 _Z16xcbReferFileNamePvPPKcPi
+0x118361B1 xcbReferFileName(void*, char const**, int*)
 0x29DD45DC sceNpScoreSetTimeout
-0xEDE62D3D _ZN3paf10PhItemSpin8SetStyleEiiRK4vec4
+0xEDE62D3D paf::PhItemSpin::SetStyle(int, int, vec4 const&)
 0x3DA90559 cellFontClearFileCache
 0x02671310 cellFsSetDefaultContainer
-0x1ED44FDD _ZN3paf13PhApplication9PostEventEPNS_7PhEventE
+0x1ED44FDD paf::PhApplication::PostEvent(paf::PhEvent*)
 0x60D0F4FA smvd2DecodePicture
 0x2BCBCED4 cellHttpUtilParseStatusLine
 0xFFBD876B __raw_spu_puttxt
@@ -8208,16 +8208,16 @@
 0x854FE623 sceNpCommerceGetDataFlagStartVsh
 0xAED1C2C8 cellGcmSetFragmentProgramControl
 0x461DC8CC cellUsbPspcmWaitRecvAsync
-0x9581B8BC _ZN4cell5Daisy16LFQueue2PopCloseEPNS0_8LFQueue2EPFiPvjE
+0x9581B8BC cell::Daisy::LFQueue2PopClose(cell::Daisy::LFQueue2*, int (*)(void*, unsigned int))
 0x58EB9E57 fabs
 0xEAC06C4B FT_Lookup_Renderer
 0x3447668A cellSysutilAvc2SetStreamingTarget
 0x38144ECF cellSailPlayerGetRepeatMode
 0x574F3677 sceNpUtilXmlUnescape
-0x1C7E659C _ZN3paf8PhScroll11ChangeValueEffi
+0x1C7E659C paf::PhScroll::ChangeValue(float, float, int)
 0x068FCBC6 sys_config_start
 0x43D522F4 cabsl
-0xBEC5537F _ZN3paf10PhProgress11SetMaxValueEf
+0xBEC5537F paf::PhProgress::SetMaxValue(float)
 0xED497B3C atx_get_encode_setting_num
 0x68AF923C cellSyncQueueTryPeek
 0x720B2726 cellAvchatJpgDecDecodeData
@@ -8225,7 +8225,7 @@
 0x4B03D5B2 f_rintf
 0x875D29D5 FT_GlyphLoader_Prepare
 0x4ABA7A3D sqlite3_last_insert_rowid
-0xD615B9BD _ZN3vsh11ContentInfo9SetLayoutEi
+0xD615B9BD vsh::ContentInfo::SetLayout(int)
 0x105EE2CB cellNetCtlTerm
 0x7DADC739 cellRudpCreateContext
 0xBA84EAB5 coshl
@@ -8240,21 +8240,21 @@
 0x58BC5870 cellCameraGetType
 0xC8D4B025 cellFt2dFiltering
 0xEDDCEE2C init_TT800
-0x21C770A3 _ZN3paf8PhButtonC1EPNS_8PhWidgetEPNS_8PhAppearE
+0x21C770A3 paf::PhButton::PhButton(paf::PhWidget*, paf::PhAppear*)
 0x1573DC3F sys_lwmutex_lock
 0x40410F89 PhiGetDisplay
-0xC0F6890C _ZN3paf13AVCopyControl10SetWSSCodeEjj
+0xC0F6890C paf::AVCopyControl::SetWSSCode(unsigned int, unsigned int)
 0x4129FE2D cellAudioPortClose
-0xE04F6BC8 _ZNK4cxml7Element12NumAttributeEv
+0xE04F6BC8 cxml::Element::NumAttribute() const
 0xA4CD494E _QN4cell5Daisy22ScatterGatherInterlockC2EPVNS0_16_AtomicInterlockEjPvPFiS5_jE
-0xF01DEFF8 _ZNKSt7codecvtIwcSt9_MbstatetE5do_inERS0_PKcS4_RS4_PwS6_RS6_
+0xF01DEFF8 std::codecvt<wchar_t, char, std::_Mbstatet>::do_in(std::_Mbstatet&, char const*, char const*, char const*&, wchar_t*, wchar_t*, wchar_t*&) const
 0x3DBCA1EB _cellAudioPathThroughLRCK_open
 0x19A0F619 PAF_Resource_GetPageNodeByID
 0xF3FBE44A cellAsfParser2GetFrameData
 0xF57E1D6F console_write
 0x0836F1F7 cellDtcpIpRead
 0xF91ABDA3 cellImeJpGetConvertString
-0xA337B314 _Z5lerp2RK4vec4S1_f
+0xA337B314 lerp2(vec4 const&, vec4 const&, float)
 0xE3D91DB3 raw_spu_read_double
 0x21807B8E towctrans
 0x47F01D6F sceNpMatching2Init2Vsh
@@ -8263,26 +8263,26 @@
 0x27427742 _sys_memmove
 0xF18986C1 epsonPrintGetPrinterInfo
 0xF44B6C30 cellPngDecGetiCCP
-0x3E1D246B _ZN3paf10PhMenuList14ChangeSelectedEi
+0x3E1D246B paf::PhMenuList::ChangeSelected(int)
 0x903F66EB SSL_CTX_set_verify_mode
-0x493A2E6D _ZN11PSJSContext12RegistGlobalEPKci
+0x493A2E6D PSJSContext::RegistGlobal(char const*, int)
 0xAB4C7CA1 _CWcsxfrm
 0xB4FC7078 _close_all_FILE
-0xE0AB62A4 _ZN3paf5Image9Convert32Ev
+0xE0AB62A4 paf::Image::Convert32()
 0x7D894764 _Readloc
-0xB9502D8B _ZN3paf10PhMenuListC1EPNS_8PhWidgetEPNS_8PhAppearE
+0xB9502D8B paf::PhMenuList::PhMenuList(paf::PhWidget*, paf::PhAppear*)
 0xEA1E83E3 f_logf
 0xC85CD08D cellM4vEncSendEncCommand
 0x5EA49E2A sceNpMatching2GetRoomDataInternalVsh
 0xB396DD41 cellGcmSetClearSurface
 0x1B752FD1 cellGcmSetTextureRemap
-0xE42DDD59 _ZNK10PSJSObject7GetAttrERK8psjsnameP9PSJSValue
+0xE42DDD59 PSJSObject::GetAttr(psjsname const&, PSJSValue*) const
 0x21182419 FT_Stream_ExtractFrame
 0x2A8E6B92 cellGameGetDiscContentInfoUpdatePath
 0x12034412 sceNpMatching2GetClanLobbyId
 0x05D65DFF sceNpScoreGetRankingByNpId
-0x6CE65E82 _ZN8cxmlutil5GetIDERKN4cxml7ElementEPKcPS5_
-0xEB1BB57F _ZN3paf7PhXmBar9SelectOutEf
+0x6CE65E82 cxmlutil::GetID(cxml::Element const&, char const*, char const**)
+0xEB1BB57F paf::PhXmBar::SelectOut(float)
 0x8E505175 cellSslCertGetRsaPublicKeyModulus
 0xA5B68C24 FT_Stream_ReadLong
 0xAF02E7DE _cellSslPemReadX509
@@ -8291,42 +8291,42 @@
 0x1324948A cellRtcFormatRfc3339LocalTime
 0x791B9219 _sys_vsprintf
 0x08975E23 scePS2McIconSys_GetLightDir2
-0x27527B03 _ZN3paf6PhFont14GetNumFontListEv
-0xB84F742B _ZN3paf8PhWidget10SetTextureERKNS_12SurfaceRCPtrINS_7SurfaceEEEi
+0x27527B03 paf::PhFont::GetNumFontList()
+0xB84F742B paf::PhWidget::SetTexture(paf::SurfaceRCPtr<paf::Surface> const&, int)
 0x94B98E39 cellPadDbgLddSetDataInsertMode
-0xC5987EC3 _ZN3paf8PhXmList10DeleteItemEif
+0xC5987EC3 paf::PhXmList::DeleteItem(int, float)
 0xEC62EB67 xRegistryTransactionEnd
 0x8A5C1460 sceNpMatching2SetRoomDataInternalVsh
 0xED10FCFE cellGcmSetInitState
 0xFFB28491 cellSearchGetContentInfoPath
 0xC7369FCE _Atan
-0xA3770DD7 _ZN3paf12PhLevelMeterC1EPNS_8PhWidgetEPNS_8PhAppearE
+0xA3770DD7 paf::PhLevelMeter::PhLevelMeter(paf::PhWidget*, paf::PhAppear*)
 0x35F02287 cellSpursQueueDepth
 0xDF856979 sys_dbg_get_event_flag_information
 0xC82558CE cellPngEncOpenEx
 0x4AB5FBE2 _Printf
-0xD8EB2AD2 _ZN3paf10PhInfoList21SetPrivateSurfacePoolEPNS_11SurfacePoolE
+0xD8EB2AD2 paf::PhInfoList::SetPrivateSurfacePool(paf::SurfacePool*)
 0x855C13DC InputDevice_EnableAnalogThreshold
-0x767A4E70 _ZNSt6_WinitC2Ev
+0x767A4E70 std::_Winit::_Winit()
 0x9165C1AE sceNpMatchingJoinRoomVsh
 0x938013A0 cellSysutilGetSystemParamString
 0x9CDE07CC sceNpCommerce2GetProductInfoListStart
 0xFF128226 canonPrintStartJob
 0xF46D8AE5 sceNpTssGetDataNoLimit
-0x8006C4EC _ZNSt9money_putIwSt19ostreambuf_iteratorIwSt11char_traitsIwEEED0Ev
-0x8B8F6C76 _ZNK3paf7PhMicon14GetVolumeDeltaEv
+0x8006C4EC std::money_put<wchar_t, std::ostreambuf_iterator<wchar_t, std::char_traits<wchar_t>>>::~money_put()
+0x8B8F6C76 paf::PhMicon::GetVolumeDelta() const
 0xE22D74A4 cellRtcSetSystemTime
 0xACF69049 xRegistryDestroyInstance
-0x8D173737 _ZN3vsh22InfobarAnimation_CloseEPN3paf4ViewEPKcS4_RNS_28InfobarAnimationInstanceDataEi
+0x8D173737 vsh::InfobarAnimation_Close(paf::View*, char const*, char const*, vsh::InfobarAnimationInstanceData&, int)
 0x9A968EEA _cellAudioStartRSX
 0x01220224 cellRescGcmSurface2RescSrc
 0x72165A7F cellMicReadRaw
 0xE0E56430 cellCryptoPuRsassaPkcs1v15Verify512
 0x090EB5C8 cellCameraSetContainer
 0x3DB7914D sceNpScoreGetRankingByNpIdAsync
-0x5F68B433 _ZN3paf8PhXmItem9PlayerEndEff
+0x5F68B433 paf::PhXmItem::PlayerEnd(float, float)
 0x4D1ADD21 _cellAudioSetDownMixer86
-0xE528A368 _ZNKSt7_MpunctIcE14do_curr_symbolEv
+0xE528A368 std::_Mpunct<char>::do_curr_symbol() const
 0x3704840E _fs_finalize
 0x8B7BBD73 sceNpMatchingSendInvitationGUI
 0x06BCC1DA R_time
@@ -8339,21 +8339,21 @@
 0xCAED32C1 cellFontGenerateCharGlyphVertical
 0x066BB1CF cellMusicDecodeSetDecodeCommand
 0x222FD339 cellNetAoiDeletePeer
-0x2B88F26E _ZNSt15basic_streambufIwSt11char_traitsIwEED0Ev
+0x2B88F26E std::basic_streambuf<wchar_t, std::char_traits<wchar_t>>::~basic_streambuf()
 0x983FB9AA cellGcmSetWaitFlip
 0xF0AECBC3 cellJpgEncCoreClose
 0xB6D92AC3 strcasecmp
 0xCBDF9AFB _log10f4fast
 0x05CB1718 f_fdimf
-0x015D4314 _ZN3vsh16Infobar_IsOpenedEv
+0x015D4314 vsh::Infobar_IsOpened()
 0x5AF74C50 cellMusicDecodeGetDecodeStatus
 0x6539FF6D _Gentime
 0x4D5E0670 sceNpScoreGetClansMembersRankingByRangeAsync
-0x854BC7C7 _ZNSt7num_getIcSt19istreambuf_iteratorIcSt11char_traitsIcEEED0Ev
+0x854BC7C7 std::num_get<char, std::istreambuf_iterator<char, std::char_traits<char>>>::~num_get()
 0x866F6AEC cellFsStReadWaitCallback
 0x3860A12A cellFiberPpuSchedulerTraceFinalize
 0x3CC8588A sceNpMatchingCreateRoomGUI
-0x823759D3 _ZNKSt7num_putIwSt19ostreambuf_iteratorIwSt11char_traitsIwEEE6do_putES3_RSt8ios_basewl
+0x823759D3 std::num_put<wchar_t, std::ostreambuf_iterator<wchar_t, std::char_traits<wchar_t>>>::do_put(std::ostreambuf_iterator<wchar_t, std::char_traits<wchar_t>>, std::ios_base&, wchar_t, long) const
 0xEF8EAFCD sceNpCommerce2DestroyGetProductInfoResult
 0x97CC91B8 gnpc_resp_get_integer
 0x677BC574 cellAvsetGetHDMIKSVListSize
@@ -8374,7 +8374,7 @@
 0x947C7B8A FTManager_CloseFace
 0x4CE3FC00 FT_Get_Multi_Master
 0x8A6D4227 cellApostSrcSetSPURSParam
-0x45D85C54 _ZN3vsh18SetCooperationModeENS_15CooperationModeE
+0x45D85C54 vsh::SetCooperationMode(vsh::CooperationMode)
 0x4C8B7E01 R_time_free
 0x702DC876 sceNpSnsFbGetAccessToken
 0x0D8A2DE0 _CStrxfrm
@@ -8385,13 +8385,13 @@
 0x3792B12D lroundl
 0x4020F5EF cbrt
 0x717B2502 stat
-0x3DA21A90 _ZNSt7num_getIwSt19istreambuf_iteratorIwSt11char_traitsIwEEED1Ev
+0x3DA21A90 std::num_get<wchar_t, std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>>::~num_get()
 0x084EB81A FT_Stream_OpenLZW
-0x09E73A2A _ZNKSt7codecvtIwcSt9_MbstatetE11do_encodingEv
-0x05063ACE _ZN3paf7PhSPrim8SetStyleEiRK4vec4
+0x09E73A2A std::codecvt<wchar_t, char, std::_Mbstatet>::do_encoding() const
+0x05063ACE paf::PhSPrim::SetStyle(int, vec4 const&)
 0x476A66AD cellGcmSetDepthMask
-0xE81D263A _ZNK3paf7Surface13GetActivePageENS0_8PageModeE
-0x5C6C78E5 _ZN3paf15CriticalSection5LeaveEv
+0xE81D263A paf::Surface::GetActivePage(paf::Surface::PageMode) const
+0x5C6C78E5 paf::CriticalSection::Leave()
 0xA27C95CA cellFiberPpuUtilWorkerControlFinalize
 0x130D20A5 towlower
 0xF99FCE24 dlnaPrintSearchPrinter
@@ -8402,7 +8402,7 @@
 0xF5F39114 _sys_net_lib_thread_join
 0xA2B8AF7C cellVideoPlayerStartThumbnail
 0x75745079 cellGifDecOpen
-0x50808C54 _ZN13PSJSValueImpl11NewFromPoolERK11PSJSContextRK10psjsvector
+0x50808C54 PSJSValueImpl::NewFromPool(PSJSContext const&, psjsvector const&)
 0xCF1AAEFA cellSysutilPrintInit
 0x21A62E9B cellMouseGetTabletDataList
 0x11EEAC9E cellMcadptGetInfo
@@ -8418,14 +8418,14 @@
 0xAF44A615 fgets
 0x5457E0B2 dlnaPrintSearchPrinterEx
 0x55DC23DE cellCelpEncStart
-0xA1D49EE6 _ZNK9PSJSValue6ToBoolEv
-0x689DCA1F _ZN3paf14PhGetTextWidthENS_6PhFont9GlyphTypeERKSbIwSt11char_traitsIwESaIwEEjjRKS0_PKNS_17PhTextLetterSpaceE
+0xA1D49EE6 PSJSValue::ToBool() const
+0x689DCA1F paf::PhGetTextWidth(paf::PhFont::GlyphType, std::basic_string<wchar_t, std::char_traits<wchar_t>, std::allocator<wchar_t>> const&, unsigned int, unsigned int, paf::PhFont const&, paf::PhTextLetterSpace const*)
 0x8BDE5EBF cellGcmSetUserCommand
 0x8A292735 smvd4GetPicture
-0x24F6808A _ZN3paf12PhDispatcher9EventExecEPNS_7PhEventE
-0xCF84FC8B _ZN3paf17PhAppearAsyncDrawC1EPKNS_8PhWidgetE
+0x24F6808A paf::PhDispatcher::EventExec(paf::PhEvent*)
+0xCF84FC8B paf::PhAppearAsyncDraw::PhAppearAsyncDraw(paf::PhWidget const*)
 0x44CD6308 remainder
-0x5BA7853B _ZN8PSJSHeapC1EPvj
+0x5BA7853B PSJSHeap::PSJSHeap(void*, unsigned int)
 0x75D4485C rename
 0xAC16777E cellWebBrowserConfigSetStatusHook2
 0x2B9BD9AD cellAudioRemoveNotifyEventQueueEx
@@ -8434,8 +8434,8 @@
 0x8443023A cellFsUtilitySetFakeSize
 0x88FB4A66 recipf4fast
 0x3138E632 cellMouseGetData
-0x38474239 _ZNK7bXCeDoc12GetFirstAttrEP8bXCeNode
-0x6E0347D4 _ZN3paf8PhXmList18SetValueLabelAlphaEfff
+0x38474239 bXCeDoc::GetFirstAttr(bXCeNode*) const
+0x6E0347D4 paf::PhXmList::SetValueLabelAlpha(float, float, float)
 0x2D2C2764 cellGemGetAllTrackableHues
 0x1BE996CC _LCdivcc
 0xEF2DA2AB x3_lib_exit
@@ -8444,12 +8444,12 @@
 0x3BCE073B putc
 0x571DC686 cellSysutilGetLicenseArea
 0x81EED68C FT_Get_CMap_Language_ID
-0x0E9698AF _ZNSt7codecvtIwcSt9_MbstatetED1Ev
+0x0E9698AF std::codecvt<wchar_t, char, std::_Mbstatet>::~codecvt()
 0xCA4181B4 sceNpClansGetClanList
 0x8D4518A0 sceNpCommerceSetDataFlagFinish
-0x3CF24218 _ZN3paf8PhWidget8GetChildEi
-0x318C080C _ZN3paf10PhInfoList13SetVisibleTopEf
-0x2388D15D _ZNK7bXCeDoc12GetAttrValueEP8bXCeNode
+0x3CF24218 paf::PhWidget::GetChild(int)
+0x318C080C paf::PhInfoList::SetVisibleTop(float)
+0x2388D15D bXCeDoc::GetAttrValue(bXCeNode*) const
 0x50EA75BC cellHttpUtilCopyStatusLine
 0x0E5FE585 cellGcmSetFlipHandler2
 0x87A08D29 cellMicGetFormatDsp
@@ -8459,7 +8459,7 @@
 0xD3EA496B cellOskDialogExtUpdatePointerDisplayPos
 0xCB377E36 sys_dbg_get_lwmutex_information
 0xCA872C41 cellGameExecGame
-0x6F1299BE _ZN3paf7PhSPrim8SetStyleEif
+0x6F1299BE paf::PhSPrim::SetStyle(int, float)
 0x7321BADB cellMarlinDRMFinTrack
 0xABC27420 wcstoul
 0xFFA3D791 cellGameUpdateCheckFinishAsync
@@ -8469,21 +8469,21 @@
 0xB18CC115 freopen
 0x06DD4174 cellSailRendererAudioFinalize
 0xB9ED25D4 raw_spu_read_ulong
-0xFD693130 _ZN3vsh11ContentInfo7InitPosEv
+0xFD693130 vsh::ContentInfo::InitPos()
 0x4C726FFC sceNpMatching2GetLobbyMemberDataInternalVsh
 0x9763E962 cellUsbdClosePipe
-0x91B0E37E _ZSt14set_unexpectedPFvvE
-0x411B923E _ZSt9use_facetISt8numpunctIcEERKT_RKSt6locale
+0x91B0E37E std::set_unexpected(void (*)())
+0x411B923E std::numpunct<char> const& std::use_facet<std::numpunct<char>>(std::locale const&)
 0xF60BE06F sceNpTusAddAndGetVariableVUser
-0x2E2B80C8 _ZNKSt7num_getIwSt19istreambuf_iteratorIwSt11char_traitsIwEEE6do_getES3_S3_RSt8ios_baseRNSt5_IosbIiE8_IostateERPv
+0x2E2B80C8 std::num_get<wchar_t, std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>>::do_get(std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>, std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>, std::ios_base&, std::_Iosb<int>::_Iostate&, void*&) const
 0x24497C52 cosf
 0xE0A6DBE4 _cellSpursSendSignal
 0x44D756D6 cellHttpUtilFormUrlEncode
 0x3B02418D sceNpScoreGetGameData
-0x3ADA193F _ZN3paf5Sound6Output8GetStateEjjP21xSettingAudioOutState
+0x3ADA193F paf::Sound::Output::GetState(unsigned int, unsigned int, xSettingAudioOutState*)
 0xBC05EF31 sceNpClansSendInvitation
 0x63FF6FF9 cellSysmoduleInitialize
-0xA922709B _ZN4rectaSEf
+0xA922709B rect::operator= (float)
 0x26709B91 cellSsDrvAuthDrive
 0x5B6CCF5A cellAtracMultiGetTrackArray
 0xF20DF7FC cellUsbPspcmCalcPoolSize
@@ -8498,7 +8498,7 @@
 0x9B98D258 cellCameraRemoveNotifyEventQueue
 0xCCA68E9C putwc
 0xE0998DBF sys_prx_get_module_id_by_name
-0x24A9E5BA _ZN3paf12PhLevelMeter6CreateEii
+0x24A9E5BA paf::PhLevelMeter::Create(int, int)
 0xBA363B3E FT_Stream_Seek
 0x4FC86B2C cellFiberPpuUtilWorkerControlDisconnectEventQueue
 0xB49EEA74 _init_malloc_lock0
@@ -8508,14 +8508,14 @@
 0x8B209CA2 sceNpMatching2GetRoomDataInternal
 0xE4C51D4C wcstoimax
 0x1BC200F4 sys_lwmutex_unlock
-0xDD32A35C _ZN3paf7PhSText14GetLayoutStyleEiRiRf
-0x74AA6AB7 _ZN3paf5Sound6Output17LoadAudioRegistryEjP24xSettingAudioOutRegistry
+0xDD32A35C paf::PhSText::GetLayoutStyle(int, int&, float&)
+0x74AA6AB7 paf::Sound::Output::LoadAudioRegistry(unsigned int, xSettingAudioOutRegistry*)
 0x533F41DF cellRemotePlayGetStatus
 0x947EFB0B cellSpursEventFlagGetTasksetAddress
 0x9595DA7E sceNetXmppSendGriefReport
 0x6A81B5E4 cellHttpResponseGetStatusLine
 0x6169F205 JISstoSJISs
-0xEA96A0D0 _ZN3paf8PhXmList11AnimIconSetERKNS_12SurfaceRCPtrINS_7SurfaceEEES5_RK4vec4iiiS8_iiiii
+0xEA96A0D0 paf::PhXmList::AnimIconSet(paf::SurfaceRCPtr<paf::Surface> const&, paf::SurfaceRCPtr<paf::Surface> const&, vec4 const&, int, int, int, vec4 const&, int, int, int, int, int)
 0x28B2977F cellM4vEncGetFrameForInput
 0x673D7B35 cellMtpSendCommand
 0xF01AC471 cellKeySheapRwmNew
@@ -8538,9 +8538,9 @@
 0x4EB5EB51 sin
 0x1ECAE195 _Vacopy
 0x4C4B9665 cellSysutilAvc2IsCameraAttached
-0xD84B3689 _ZdlPv
+0xD84B3689 operator delete(void*)
 0x52A1F1EC FT_Outline_GetInsideBorder
-0x3697BBD3 _ZNSt8ios_base5_InitEv
+0x3697BBD3 std::ios_base::_Init()
 0xC611029A sceNpUtilGetPlatformType
 0xA3457869 cellHttpUtilParseProxy
 0x9B882495 cellFsGetDirectoryEntries
@@ -8554,9 +8554,9 @@
 0x571AFACA cellSslCertificateLoader
 0x1D344406 cellSpursTaskGetLoadableSegmentPattern
 0x1B449418 smf_ApPl_GetMediaTimeBySampleNo
-0xBB1262AA _ZN10bXCeMemMgrdlEPv
+0xBB1262AA bXCeMemMgr::operator delete(void*)
 0x7DD4A974 sqlite3_errcode
-0xC4C7993B _ZNSbIwSt11char_traitsIwESaIwEE5_TidyEbj
+0xC4C7993B std::basic_string<wchar_t, std::char_traits<wchar_t>, std::allocator<wchar_t>>::_Tidy(bool, unsigned int)
 0x1F402F8F cellSpursGetInfo
 0x1F6328D8 cellGemWriteExternalPort
 0x5D81B912 cellCryptoPuSha256Init
@@ -8566,24 +8566,24 @@
 0x0C7CB9F7 cellSyncLFQueueGetEntrySize
 0x92D5C77B sceNpMatchingGetRoomListWithoutGUI
 0x8A491559 cellMgVideoFormatICV
-0x00CF44F7 _ZNKSt7num_putIcSt19ostreambuf_iteratorIcSt11char_traitsIcEEE6do_putES3_RSt8ios_basecl
-0x5ADA82A5 _ZN3paf7PhMicon9SetVolumeEf
+0x00CF44F7 std::num_put<char, std::ostreambuf_iterator<char, std::char_traits<char>>>::do_put(std::ostreambuf_iterator<char, std::char_traits<char>>, std::ios_base&, char, long) const
+0x5ADA82A5 paf::PhMicon::SetVolume(float)
 0xA0237F5E ft_mem_realloc
 0xD5F9A15B cellSailDescriptorGetStreamType
-0xE196BEAB _ZNSt9money_getIwSt19istreambuf_iteratorIwSt11char_traitsIwEEED0Ev
-0xD526FD70 _ZNK4cxml9Attribute6GetIntEPi
+0xE196BEAB std::money_get<wchar_t, std::istreambuf_iterator<wchar_t, std::char_traits<wchar_t>>>::~money_get()
+0xD526FD70 cxml::Attribute::GetInt(int*) const
 0x47CA71EF cellFontAdjustFontScaling
 0x5EB95641 _Stold
-0xD1EE6195 _ZNKSt8time_putIcSt19ostreambuf_iteratorIcSt11char_traitsIcEEE6do_putES3_RSt8ios_basecPKSt2tmcc
+0xD1EE6195 std::time_put<char, std::ostreambuf_iterator<char, std::char_traits<char>>>::do_put(std::ostreambuf_iterator<char, std::char_traits<char>>, std::ios_base&, char, std::tm const*, char, char) const
 0x35D6B9CC cellAvcEncClose
 0x05028763 jis2kuten
 0xA41342DC cellFontGraphicsGetFontRGBA
 0xCED17573 cellSaveDataFixedDelete
 0xFF03CC79 cellSpursJobQueueAttributeSetIsHaltOnError
 0x42BAABB8 cellMgVideoAuth
-0xF5116A56 _ZNK3paf7PhSText8GetStyleEiRf
+0xF5116A56 paf::PhSText::GetStyle(int, float&) const
 0x6941C365 pafGuTexWrap
-0x9FACB533 _ZNSt13messages_baseD1Ev
+0x9FACB533 std::messages_base::~messages_base()
 0x36472C57 cellVoiceReadFromOPort
 0xDF982D2C cellAdecOpenExt
 0x6C815943 cellFsLsnGetCDASize
@@ -8595,9 +8595,9 @@
 0x64A10EC8 UCS2toUTF16
 0x02F4D325 spu_thread_read_double
 0x50B83205 cellPamfEpIteratorMove
-0x41EF8D0F _ZN8PSJSHeapD1Ev
+0x41EF8D0F PSJSHeap::~PSJSHeap()
 0x8297F1EC sceNpManagerRequestTicket2
-0xF05DF017 _ZNSt5ctypeIcE7_GetcatEPPKNSt6locale5facetE
+0xF05DF017 std::ctype<char>::_Getcat(std::locale::facet const**)
 0x8CB6BFDC _Locsum
 0xE76E79AB cellUsbPspcmCancelWaitData
 0xA3E3BE68 sys_ppu_thread_once
@@ -8606,11 +8606,11 @@
 0x4232B0DB _sys_panic
 0xC8971DB5 cellWebBrowserSetLocalContentsAdditionalTitleID
 0xF76847C2 sceNpScoreRecordGameDataAsync
-0xFACEACC7 _ZN3paf5PhWeb4StopEv
+0xFACEACC7 paf::PhWeb::Stop()
 0xBA901FE6 cellFsMkdir
 0x6C511024 sceNpTusGetMultiUserVariableVUser
 0x94862702 cellMsgDialogProgressBarInc
-0xCBA8AA7C _ZN3paf16SaveDataResourceC1EPvjRKSsb
+0xCBA8AA7C paf::SaveDataResource::SaveDataResource(void*, unsigned int, std::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, bool)
 0xEE7528F3 cellWebBrowserConfigSetRequestHook2
 0xDE6D308B sceNpMatching2GetRoomPasswordLocal
 0x05371C8D cellDmuxDisableEs
@@ -8618,42 +8618,42 @@
 0x32200389 sceNpManagerGetMyLanguages
 0xF88F26C4 fwrite
 0xB0F08283 cellGcmSysSetSurface
-0x5919DAD3 _Z16pafGumLoadMatrixPK4mat4
+0x5919DAD3 pafGumLoadMatrix(mat4 const*)
 0x532B03BE raw_spu_read_uint
 0xBF47C5DD cellCameraInit
-0x0D644DCA _ZNKSt8time_getIcSt19istreambuf_iteratorIcSt11char_traitsIcEEE11do_get_dateES3_S3_RSt8ios_baseRNSt5_IosbIiE8_IostateEPSt2tm
+0x0D644DCA std::time_get<char, std::istreambuf_iterator<char, std::char_traits<char>>>::do_get_date(std::istreambuf_iterator<char, std::char_traits<char>>, std::istreambuf_iterator<char, std::char_traits<char>>, std::ios_base&, std::_Iosb<int>::_Iostate&, std::tm*) const
 0xFE7D5E4F FT_Set_Var_Design_Coordinates
 0x5AC783DC EUCJPstoUTF8s
 0xFF42DCC3 cellFsClosedir
 0xF89B1D92 cellAvcEncSmallOpenExt
 0x780960F1 cellGcmSetClearZcullSurface
 0xC1D6771B smvd4GetVersionNumber
-0x7EB8896A _ZN3paf5PhWeb9UISession5replyENS1_9ReplyCodeEPKw
+0x7EB8896A paf::PhWeb::UISession::reply(paf::PhWeb::UISession::ReplyCode, wchar_t const*)
 0xE558748D cellVideoOutGetResolution
-0x67C09257 _ZNKSt7num_getIcSt19istreambuf_iteratorIcSt11char_traitsIcEEE6do_getES3_S3_RSt8ios_baseRNSt5_IosbIiE8_IostateERx
+0x67C09257 std::num_get<char, std::istreambuf_iterator<char, std::char_traits<char>>>::do_get(std::istreambuf_iterator<char, std::char_traits<char>>, std::istreambuf_iterator<char, std::char_traits<char>>, std::ios_base&, std::_Iosb<int>::_Iostate&, long long&) const
 0x7871BED4 cellVideoOutUnregisterCallback
 0xF7844153 _f_fmaxf
-0x696B47F2 _ZNKSt7_MpunctIcE13do_neg_formatEv
+0x696B47F2 std::_Mpunct<char>::do_neg_format() const
 0x8B7ED64B cellSaveDataAutoSave2
 0x118CAF26 sceNpMatching2RegisterRoomMessageCallbackVsh
 0xD2A666C9 ctanh
-0xDBFE46EA _ZN3paf9PhHandler16HandlePointEventEPNS_7PhEventE
-0x6DAED882 _ZNSt8ios_baseD0Ev
+0xDBFE46EA paf::PhHandler::HandlePointEvent(paf::PhEvent*)
+0x6DAED882 std::ios_base::~ios_base()
 0x89D8C76B cellGcmSetPolygonOffsetFillEnable
 0xCE6CB776 cellOvisFixSpuSegments
 0x3548F483 _cellSpursJobChainAttributeInitialize
 0xFC6F4E74 cellScreenShotDisable
-0xAC0EB3AB _ZN3paf8PhXmList18SetFocusInTopColorERK4vec4ff
-0x2E84EBB3 _ZNSt8_LocinfoC1EiPKc
+0xAC0EB3AB paf::PhXmList::SetFocusInTopColor(vec4 const&, float, float)
+0x2E84EBB3 std::_Locinfo::_Locinfo(int, char const*)
 0xB2FCF2C8 _sys_heap_create_heap
 0x313FEF79 sceNpMatching2SetLobbyMemberDataInternalVsh
 0x4FFBA189 feof
 0x9E3ADA21 logl
-0xB8EC13A5 _ZNKSt7num_putIwSt19ostreambuf_iteratorIwSt11char_traitsIwEEE6do_putES3_RSt8ios_basewb
+0xB8EC13A5 std::num_put<wchar_t, std::ostreambuf_iterator<wchar_t, std::char_traits<wchar_t>>>::do_put(std::ostreambuf_iterator<wchar_t, std::char_traits<wchar_t>>, std::ios_base&, wchar_t, bool) const
 0x6884CDB7 cellHttpClientGetResponseBufferMax
-0x3B7BD1AC _ZN3paf5PhWeb9UISession5replyENS1_9ReplyCodeE
+0x3B7BD1AC paf::PhWeb::UISession::reply(paf::PhWeb::UISession::ReplyCode)
 0xBC5AF0B5 fgetwc
-0x10893289 _ZN3paf8PhWidget12UpdateMatrixEv
+0x10893289 paf::PhWidget::UpdateMatrix()
 0x9997E6B6 cellSysutilGameDataAssignVmc
 0x4AC10F4F divxDecGetNumOfPictures
 0xB0C51412 sceNpMatching2GetRoomMemberDataInternal
@@ -8661,7 +8661,7 @@
 0x70A0FDE4 sceLoginServiceTerm
 0xA1709ABD sceNpManagerGetEntitlementById
 0x9ABE8C74 wprintf
-0x0FF264B9 _ZNSt15basic_streambufIcSt11char_traitsIcEE4syncEv
+0x0FF264B9 std::basic_streambuf<char, std::char_traits<char>>::sync()
 0xF3DBF5A7 cellSysutilSetBgmPlaybackExtraParam
 0x21FC0C71 cellGameUnregisterDiscChangeCallback
 0x080414BD conjl
@@ -8669,13 +8669,13 @@
 0x772F1E4D lround
 0xD8310700 cellRudpPollWait
 0x368823C0 sys_net_get_netemu_test_param
-0x5FF12E92 _ZN4xMMS29CreateGenerateMetadataContextEPP19xMMSGenerateContext
+0x5FF12E92 xMMS::CreateGenerateMetadataContext(xMMSGenerateContext**)
 0x489102C6 cellSsRngGetPseudoRandomNumber
-0x1B6A7482 _ZNKSt7_MpunctIwE13do_neg_formatEv
+0x1B6A7482 std::_Mpunct<wchar_t>::do_neg_format() const
 0x66F19527 sceNpMatching2KickoutRoomMember
 0x4ABE18A1 sceNetFreeInternal
 0xD18B0627 BIO_set_cb_arg
-0x01C4EF01 _ZNSt6localeC2ERKS_S1_i
+0x01C4EF01 std::locale::locale(std::locale const&, std::locale const&, int)
 0x4DE475D7 cellM4vEncGetStream
 0x40E895D3 cellSysutilGetSystemParamInt
 0x348DBCB4 sceNpTusGetMultiUserDataStatus
@@ -8688,8 +8688,8 @@
 0x06574237 _sys_snprintf
 0x24FA3BCC cellFsAclRead
 0x6823C180 iswprint
-0x5F096D38 _Z18pafGumLoadIdentityv
-0xFE5A7950 _ZN3paf9PhHandler10DoCallBackEiPNS_7PhEventE
+0x5F096D38 pafGumLoadIdentity()
+0xFE5A7950 paf::PhHandler::DoCallBack(int, paf::PhEvent*)
 0xB68CCFE8 cellAvcEncGetLocalDecodedFrame
 0x08DB2ADF cellSysconfBtGetDeviceList
 0xF37209FA cellAvsetSetAudioMode
@@ -8711,7 +8711,7 @@
 0x6DB792AE cellGcmSetVertexProgramParameter
 0x7AEE5ACD _Lockfilelock
 0xE3072DF9 smvd2Initialize
-0xD251AE84 _ZN3paf8DateTime17SetDateTimeFormatEPKw
+0xD251AE84 paf::DateTime::SetDateTimeFormat(wchar_t const*)
 0x384C2F1E smf_ApRc_SetVideoProfileInfo
 0x12D9B6C5 cellJpgEncQueryAttr
 0x1350864E cellCameraResetAttribute
@@ -8724,13 +8724,13 @@
 0xBE50B11E cellMusicInitialize2
 0x352EFDDF sceNetCtlTermVsh
 0x2A78FF04 cellHttpTransactionGetSslId
-0xCF9B4D80 _ZNSt10moneypunctIwLb1EED0Ev
+0xCF9B4D80 std::moneypunct<wchar_t, true>::~moneypunct()
 0x04C19A94 PhiUpdateDisplay
 0xADAB4B10 canonPrintGetStatus
 0x325C6284 sceNpTusAbortTransaction
-0xB8A630CD _ZNK3paf11SurfaceBase13PixelsToBytesEi
+0xB8A630CD paf::SurfaceBase::PixelsToBytes(int) const
 0xA9A079E0 inet_aton
-0xBAA15803 _ZSt4setwi
+0xBAA15803 std::setw(int)
 0xD22D4C58 cellGcmSetZcullControl
 0x40B34847 cellSaveDataUserFixedSave
 0x8E3F2C40 cellFontGlyphRenderImageVertical
@@ -8743,29 +8743,29 @@
 0xBF014813 sceNpMatching2SignalingSetCtxOpt
 0x13DAD160 sceNpMatching2GetRoomPasswordLocalVsh
 0xBE42E661 eucjpzen2han
-0xA9E5BB16 _ZNKSt7num_getIcSt19istreambuf_iteratorIcSt11char_traitsIcEEE6do_getES3_S3_RSt8ios_baseRNSt5_IosbIiE8_IostateERm
+0xA9E5BB16 std::num_get<char, std::istreambuf_iterator<char, std::char_traits<char>>>::do_get(std::istreambuf_iterator<char, std::char_traits<char>>, std::istreambuf_iterator<char, std::char_traits<char>>, std::ios_base&, std::_Iosb<int>::_Iostate&, unsigned long&) const
 0xADDF33CD cellFsWidgetOpendir
-0xC2E555BA _ZN3paf8PhWidget6GetRotEPS0_RK4vec4i
+0xC2E555BA paf::PhWidget::GetRot(paf::PhWidget*, vec4 const&, int)
 0xCD7BC431 cellAudioPortOpen
 0x68AAEBA9 cellSpursJobGuardInitialize
 0x9B45DE35 atxenc_query_input_pcm_bytes
 0x67CB1BDA CEUThread_self
 0xF0776A44 wcscmp
 0xF456AD89 ps_hints_apply
-0x2AE5330D _ZN11PSJSContext22SetHeapIsEmptyCallbackEPFvPvES0_
+0x2AE5330D PSJSContext::SetHeapIsEmptyCallback(void (*)(void*), void*)
 0xCAC167A5 _Cmulcc
 0xE31BD1CA cellDtcpIpClose
 0x211A3AA5 CEUSemaphore_wait
 0xE1FB0EBD cellHttpUtilParseHeader
 0x23B985F7 floorf
 0x32B94ADD cellSpursEnableExceptionEventHandler
-0x0ACCBD0C _ZN3paf8PhIPAddr8SetValueEPh
-0xA8ECE2E0 _ZSt9use_facetISt10moneypunctIwLb0EEERKT_RKSt6locale
-0x7415A11D _ZN3paf8PhCamera16SetVirtualScreenEfff
+0x0ACCBD0C paf::PhIPAddr::SetValue(unsigned char*)
+0xA8ECE2E0 std::moneypunct<wchar_t, false> const& std::use_facet<std::moneypunct<wchar_t, false>>(std::locale const&)
+0x7415A11D paf::PhCamera::SetVirtualScreen(float, float, float)
 0x1C153E5C sceNpCommerce2EmptyStoreCheckAbort
 0xD6811AA7 cellVoiceGetSignalState
 0x626E8518 cellGcmMapEaIoAddressWithFlags
-0x4922A06A _ZN3paf14GraphicsMemory4Area13AllocFromHeapENS0_10DeviceTypeEijj
+0x4922A06A paf::GraphicsMemory::Area::AllocFromHeap(paf::GraphicsMemory::DeviceType, int, unsigned int, unsigned int)
 0x71F4C717 gethostbyname
 0x20BAFE31 cellVoiceDebugTopology
 0x85B07126 cellSailMp4MovieGetTrackById
@@ -8774,37 +8774,37 @@
 0xDDD19A89 cellMicStartEx
 0x55104762 FT_Get_BDF_Charset_ID
 0xF463981C cellGameUpdateCheckFinishAsyncEx
-0x10231873 _ZNSt13runtime_errorD1Ev
+0x10231873 std::runtime_error::~runtime_error()
 0xBAB91FC9 sceNpBasicGetPlayersHistoryEntry
 0x3EEEDB0E _Dclass
 0xBD1C5D6B _cellSpursJobQueuePortPushFlush
-0x7B1DB41E _ZNSt6locale7_AddfacEPNS_5facetEjj
+0x7B1DB41E std::locale::_Addfac(std::locale::facet*, unsigned int, unsigned int)
 0x18DD4604 cellFsOpen2
 0x2EC867B4 exp2f4fast
 0xAFC21C3E sys_net_get_routing_table_af
 0xE44827ED cellFsAclWrite
 0x57390C45 cellSailComposerGetEsAudioAu
 0x9B820047 sceNpClansInit
-0x0490855D _ZNSt8numpunctIwE7_GetcatEPPKNSt6locale5facetE
+0x0490855D std::numpunct<wchar_t>::_Getcat(std::locale::facet const**)
 0x5B162B7F memmove
 0xBD100DBC cellGcmSetTileInfo
-0x9FBCD5C8 _ZNK3paf7PhPlane9IsInheritEPKc
+0x9FBCD5C8 paf::PhPlane::IsInherit(char const*) const
 0x8C967AA6 sceNetMallocVsh
 0xB90C871B cellFiberPpuContextCheckStackLimit
 0x6EED4999 cellHttpClientSetAuthenticationCacheStatus
 0x72EC14B5 cellMusicInitialize
 0xAE6EB491 cellSslCertGetIssuerName
-0xC7B03EDE _ZN13bXCeXMLParser5ResetEv
+0xC7B03EDE bXCeXMLParser::Reset()
 0xA8FAE920 cellFontGlyphGetOutlineControlDistance
 0xD85B4BED smvd4GetMemorySize2
 0xE6A7DE0A ungetc
 0x716F8792 cellJpgDecExtDecodeData
 0x122E0D0F cellVideoUploadInitialize
-0xE9D7A4AE _ZNKSt8time_putIwSt19ostreambuf_iteratorIwSt11char_traitsIwEEE6do_putES3_RSt8ios_basewPKSt2tmcc
+0xE9D7A4AE std::time_put<wchar_t, std::ostreambuf_iterator<wchar_t, std::char_traits<wchar_t>>>::do_put(std::ostreambuf_iterator<wchar_t, std::char_traits<wchar_t>>, std::ios_base&, wchar_t, std::tm const*, char, char) const
 0x14F504B8 EUCKRstoUCS2s
 0x21FC151F cellCameraReadEx
 0x1AE2ACEE EUCCNstoUTF8s
-0x4FDE96DE _ZNSt15basic_streambufIwSt11char_traitsIwEED1Ev
+0x4FDE96DE std::basic_streambuf<wchar_t, std::char_traits<wchar_t>>::~basic_streambuf()
 0x550D3527 cellDtcpIpStopAuthentication
 0x9A71E740 cellSailComposerGetStreamParameter
 0xB2E761D4 cellGcmResetFlipStatus
@@ -8812,7 +8812,7 @@
 0x1D46FEDF cellSpursCreateTaskWithAttribute
 0x53E38FF2 FTFaceH_GetRenderEffectSlant
 0xFFE0160E cellGcmSetVBlankFrequency
-0xAFBBD0B7 _ZNK3paf5PhWeb7HasPrevEv
+0xAFBBD0B7 paf::PhWeb::HasPrev() const
 0x2FA854AE divxDecReleasePicture
 0x5316B4A8 cellRtcIsLeapYear
 0xD0FD3CA8 _hypotf4
@@ -8820,23 +8820,23 @@
 0xC267987B cellRemotePlayGetSharedMemory
 0xA609F3E9 JISstoEUCJPs
 0xBB165807 expm1f
-0xFEDE9551 _ZN3paf8PhXmList13SetArrowAlphaEfff
+0xFEDE9551 paf::PhXmList::SetArrowAlpha(float, float, float)
 0xB348C5C2 _LLgamma
 0xC334F696 cellJpgEncCoreEncodeData
 0xCB6A147E _cosf4fast
 0x4172107C sceSystemFileCalcSizeW
-0x96599FE7 _ZN3paf10PhItemSpin8SetStyleEiib
-0xA35033E8 _ZNKSt5ctypeIwE8do_widenEPKcS2_Pw
+0x96599FE7 paf::PhItemSpin::SetStyle(int, int, bool)
+0xA35033E8 std::ctype<wchar_t>::do_widen(char const*, char const*, wchar_t*) const
 0x7F3963F7 cellVoiceResumePortAll
 0x4A5B9659 cellKeySheapBufferNew
 0xAA5A7DEF cellMarlinDLLicenseDownloadAndSave
 0xD3A346A8 tanl
 0x30DEE7B7 atxenc_get_channels
 0x127716F0 smf_ApRc_GetAtomPosition
-0xB326F699 _ZNKSt9money_putIcSt19ostreambuf_iteratorIcSt11char_traitsIcEEE6do_putES3_bRSt8ios_basece
+0xB326F699 std::money_put<char, std::ostreambuf_iterator<char, std::char_traits<char>>>::do_put(std::ostreambuf_iterator<char, std::char_traits<char>>, bool, std::ios_base&, char, long double) const
 0x5FE71606 epsonPrintEndJob
 0xD9F7CC7A cellPostNrQueryAttributes
-0xADCC5ADA _Z37sce_np_matching_set_matching2_runningb
+0xADCC5ADA sce_np_matching_set_matching2_running(bool)
 0x2C601F3B csinl
 0x8ADADF65 _cellSpursTaskAttribute2Initialize
 0x1F925C41 _allocate_mapped_pages
@@ -8844,40 +8844,40 @@
 0xDBBA2DDE dlnaPrintSendBand
 0xF43C647A sceNpMatching2ContextStop
 0x64F1F292 ft_lzwstate_init
-0x316B7A34 _ZNSt9exceptionD1Ev
-0xF69F1EC1 _ZN3paf5PhWeb27SetChangeFocusedUrlCallbackEPFvPS0_PKwE
+0x316B7A34 std::exception::~exception()
+0xF69F1EC1 paf::PhWeb::SetChangeFocusedUrlCallback(void (*)(paf::PhWeb*, wchar_t const*))
 0xF0958F73 cellRecSetInfo
-0x598BE02E _Z13xcbIsCanceledPv
+0x598BE02E xcbIsCanceled(void*)
 0xFA0583C6 sceNpMatching2SetLobbyMemberDataInternal
 0xBA65DE6D sceNpCommerceGetChildCategoryInfo
 0x5868A9F7 cellGcmGetLastFlipTime2
 0x7FE92C54 cellUsbdRegisterExtraLdd
 0x9C056962 socket
 0xEAC7CA2C ceilf4
-0x1694F8CA _ZN4xMMS11GetMetadataEyPPv
+0x1694F8CA xMMS::GetMetadata(unsigned long long, void**)
 0x7A9C2243 cellScreenShotSetOverlayImage
 0x02C5417A cellSysutilAvc2GetPlayerInfo
 0x1B119958 cellImeJpOpen3
 0x59F7579C sceNpMatchingSendRoomMessageVsh
 0xD20D7798 sceNpMatchingKickRoomMemberWithOpt
-0x96634E42 _ZNKSt9bad_alloc4whatEv
+0x96634E42 std::bad_alloc::what() const
 0x07296D93 SSL_CTX_use_PrivateKey
 0x9A556A5F FTFaceH_Close
-0x683CA70A _ZNKSt12_String_base5_XlenEv
-0xB4BAF07E _ZN3vsh21TextureAnimation_StopEPN3paf8PhWidgetERNS_20TextureAnimationDataE
+0x683CA70A std::_String_base::_Xlen() const
+0xB4BAF07E vsh::TextureAnimation_Stop(paf::PhWidget*, vsh::TextureAnimationData&)
 0x0C839804 smf_ApPs_GetSampleSize
-0x46D0F875 _ZNK3paf4View7GetPageEPKc
+0x46D0F875 paf::View::GetPage(char const*) const
 0x2FF0B98F sceNpGetAboutMe
 0xBDB18F83 _sys_malloc
 0x479C65D0 sceNpTusGetFriendsDataStatus
 0x2F96E40A cellGcmSetDitherEnable
-0x2AF79BD6 _ZNKSt7num_putIcSt19ostreambuf_iteratorIcSt11char_traitsIcEEE5_IputES3_RSt8ios_basecPcj
+0x2AF79BD6 std::num_put<char, std::ostreambuf_iterator<char, std::char_traits<char>>>::_Iput(std::ostreambuf_iterator<char, std::char_traits<char>>, std::ios_base&, char, char*, unsigned int) const
 0x9825A0FC sceNpCommerce2DoProductBrowseStartAsync
 0x29C137D8 Zi8AttachPUD
 0x3F062337 cellSsAimChkregPsCode
 0xD8D930BC smvd2Discontinue
 0x325039B9 cellSailRendererAudioNotifyOutputEos
-0x0A03DEFC _ZN3paf6PhSpin8DrawThisEjb
+0x0A03DEFC paf::PhSpin::DrawThis(unsigned int, bool)
 0xA5D06BF0 sys_prx_get_module_list
 0xDF3C532A _cellSync2CondAttributeInitialize
 0xF745465C FT_Stream_GetChar
@@ -8886,22 +8886,22 @@
 0xE2EA549B cellAdecEndSeq
 0x78946D1F cellVideoExportFromFileWithCopy
 0x914CFE31 sqlite3_expired
-0x88052736 _ZTv0_n12_NSt10ostrstreamD0Ev
+0x88052736 virtual thunk to std::ostrstream::~ostrstream()
 0xEF9E83D2 cellAvchatJpgDecDecodeData2
 0x8DF2765A FTRenderBuf_RenderGlyphImage
 0x48FF0164 cellDtcpIpActivate
 0x53BEF958 smvd4GetNumPicture
 0x18049621 cellGcmSetBlendFunc
 0xCA463458 _Log
-0x593FB1E5 _ZN3paf8PhWidget11RemoveChildEPKS0_
+0x593FB1E5 paf::PhWidget::RemoveChild(paf::PhWidget const*)
 0x6176961D cellHidRegisterHotKeyObserver
 0x48760C1C dlnaPrintGetPrintParam
 0xF4009A94 cellSailSourceNotifyMediaStateChanged
 0x1B890AD2 cellSsUmGetTokenSeed
 0x69E4C2FC sceNpTermVsh
-0xA22D5DDA _ZNSt8messagesIcED0Ev
+0xA22D5DDA std::messages<char>::~messages()
 0x04AF4D22 FT_Outline_GetOutsideBorder
-0xC27EF445 _ZN3vsh19ScreenSaver_SetTimeEj
+0xC27EF445 vsh::ScreenSaver_SetTime(unsigned int)
 0xBDCF8383 cellOskDialogExtRegisterKeyboardEventHookCallbackEx
 0xFDEB276A cellAvcEncSmallGetFrameForInput
 0x987E260E cellKeySheapQueueNew
@@ -8913,15 +8913,15 @@
 0x33435818 SJISstoUTF8s
 0xECACA8AD xRegistrySetValue
 0x28F8D898 cellAvcEncRestart
-0x129EE11A _ZN7bXCeDoc11RemoveChildEP8bXCeNodeS1_
+0x129EE11A bXCeDoc::RemoveChild(bXCeNode*, bXCeNode*)
 0x559234A3 cellRtcAlarmUnregister
-0x80F5B53C _ZN2ss17update_manager_if15is_product_modeERh
+0x80F5B53C ss::update_manager_if::is_product_mode(unsigned char&)
 0x37E1F502 cellCrossControllerInitialize
 0xB641168E cellMusicDecodeInitialize2SystemWorkload
 0x82F294B2 cellOvisGetOverlayTableSize
 0x1BB675C2 cellSyncMutexLock
 0xEA2D4881 cellImeJpGetConvertYomiString
-0x88DDE2F3 _Z17pafGumStoreMatrixP4mat4
+0x88DDE2F3 pafGumStoreMatrix(mat4*)
 0x9234F738 raw_spu_read_int
 0xF91639F9 cellMusicDecodeGetSelectionContext2
 0x14EE3649 sjis2jis
@@ -8929,14 +8929,14 @@
 0x812ED488 cabsf
 0x0080FE88 cellSync2MutexUnlock
 0xE853D388 sceNpSignalingGetConnectionFromNpId
-0xB1D76416 _ZN8PSJSHeap12get_heapareaEPPcPj
+0xB1D76416 PSJSHeap::get_heaparea(char**, unsigned int*)
 0xF537D837 _truncf4
 0x28563CCF cellGcmSetFragmentProgramParameter
-0xB1550B3C _ZNKSt7num_putIcSt19ostreambuf_iteratorIcSt11char_traitsIcEEE6do_putES3_RSt8ios_basecx
+0xB1550B3C std::num_put<char, std::ostreambuf_iterator<char, std::char_traits<char>>>::do_put(std::ostreambuf_iterator<char, std::char_traits<char>>, std::ios_base&, char, long long) const
 0x9DCDE367 jis2eucjp
 0x2652326B sceNpInstallerGetNpEnv
 0xAFAFEDB1 cellVideoPlayerEndThumbnail
-0x33A47C59 _ZN3paf8PhXmList18SetOtherLabelAlphaEfff
+0x33A47C59 paf::PhXmList::SetOtherLabelAlpha(float, float, float)
 0xDA5FF19C sceLoginServiceGetNpId
 0x6005CDE1 _sys_net_errno_loc
 0x8A00F264 cellPadPeriphGetData
@@ -8945,18 +8945,18 @@
 0x52541151 cellSaveDataFixedImport
 0x9BD1F890 sceNpTrophyGetLatestTrophies
 0xC6C5F3C6 _QN4cell5Daisy4Lock9pushCloseEv
-0xAD3777A2 _ZNSt13basic_filebufIcSt11char_traitsIcEE8overflowEi
-0x550255F7 _ZNKSt7codecvtIccSt9_MbstatetE10do_unshiftERS0_PcS3_RS3_
+0xAD3777A2 std::basic_filebuf<char, std::char_traits<char>>::overflow(int)
+0x550255F7 std::codecvt<char, char, std::_Mbstatet>::do_unshift(std::_Mbstatet&, char*, char*, char*&) const
 0xF83A372F f_fmaf
 0x4026EAC5 sceNpBasicRegisterContextSensitiveHandler
-0xC028CB7C _ZN3paf8PhWidget9StartAnimEb
+0xC028CB7C paf::PhWidget::StartAnim(bool)
 0xDBF22BD1 cellRecQueryMemSize
-0xF7A67D49 _ZN3vsh30SetButtonNavigationString_ViewEPKw
+0xF7A67D49 vsh::SetButtonNavigationString_View(wchar_t const*)
 0x9027FD99 _WStoldx
 0xBDF21B0F cellSailPlayerBoot
-0xE513DBB0 _ZN3paf8PhCanvasD2Ev
+0xE513DBB0 paf::PhCanvas::~PhCanvas()
 0x016556DF _sinf4
-0xF61F19E1 _ZN3paf5Image4OpenEPvjP12malloc_stateNS_11ImageFormatE
+0xF61F19E1 paf::Image::Open(void*, unsigned int, malloc_state*, paf::ImageFormat)
 0x9AF9918E cellSsSrtcSetTime
 0x41A413B3 ATEcommitPredictiveItem
 0x3402C4F9 cellGcmSetDrawEnd
@@ -8965,31 +8965,31 @@
 0x7AE82E0F vsprintf
 0x97AEDED8 cellGcmSetReturnCommand
 0x0F5A2AFB cellSysutilAvc2GetVideoMuting
-0x75824DE0 _ZNSt6_MutexC1Ev
+0x75824DE0 std::_Mutex::_Mutex()
 0x489E22F1 cellAtracMultiGetNextDecodePosition
 0xD4049DE0 cellSailMp4MovieIsCompatibleBrand
 0x017024A8 cellMicGetDeviceGUID
 0x3D901A10 _ceilf4
-0xED372406 _ZN2ss17update_manager_if14get_token_seedEyyyy
-0x1877D62E _ZN3vsh11ContentInfo9GetWidgetEi
-0x50B34C09 _ZNKSt9exception4whatEv
+0xED372406 ss::update_manager_if::get_token_seed(unsigned long long, unsigned long long, unsigned long long, unsigned long long)
+0x1877D62E vsh::ContentInfo::GetWidget(int)
+0x50B34C09 std::exception::what() const
 0xAC80DB63 CEComGetMaxHeapSize
 0xE22ED55D cellWebBrowserConfigSetFunction2
-0xA4514F28 _ZN3paf10PhItemSpinC1EPNS_8PhWidgetEPNS_8PhAppearE
+0xA4514F28 paf::PhItemSpin::PhItemSpin(paf::PhWidget*, paf::PhAppear*)
 0x7DAC520C cellCameraGetBufferSize
 0x15BDCC00 rand
-0xE8691BE5 _ZNSt5ctypeIwED0Ev
+0xE8691BE5 std::ctype<wchar_t>::~ctype()
 0xCC18CD2C sceNpCommerce2CreateSessionStart
-0x6ADC320A _ZNSt9money_getIcSt19istreambuf_iteratorIcSt11char_traitsIcEEED0Ev
-0xB8979AD7 _ZN3paf9PhSRender8SetStyleEiRK4vec4
+0x6ADC320A std::money_get<char, std::istreambuf_iterator<char, std::char_traits<char>>>::~money_get()
+0xB8979AD7 paf::PhSRender::SetStyle(int, vec4 const&)
 0xDB769B32 cellGcmMapLocalMemory
 0xE61CB17A _sys_net_lib_free
 0xBBBC2C1C cellCelp8EncEnd
-0x2A9807CD _ZN4xMMS8FinalizeEv
-0x2DBA5B93 _ZN3paf6PhText21SetPrivateSurfacePoolEPNS_11SurfacePoolE
+0x2A9807CD xMMS::Finalize()
+0x2DBA5B93 paf::PhText::SetPrivateSurfacePool(paf::SurfacePool*)
 0x0D15043B sceNpTusGetMultiUserVariable
 0xAA6C2C43 sceNpMatching2ClearEventData
-0xCE7BB5C7 _ZN3vsh9ExitParamC1Ev
+0xCE7BB5C7 vsh::ExitParam::ExitParam()
 0xD56E27AF cellPostNrClose
 0x705985CD cellSyncQueueTryPush
 0xBA50BC23 cellCelpEncOpenExt
@@ -9003,30 +9003,30 @@
 0x300B99F2 cellCryptoPuSha1HmacFinal
 0x13A37C83 atxenc_get_bitrate
 0xFD51609E cellAvchatJpgDecClose
-0xBBD06A2A _ZNK3paf5PhWeb11GetEncodingEv
+0xBBD06A2A paf::PhWeb::GetEncoding() const
 0xAF86C77A sceNpSnsFbLoadThrottle
-0x7FE08910 _ZNSt10moneypunctIcLb0EE7_GetcatEPPKNSt6locale5facetE
+0x7FE08910 std::moneypunct<char, false>::_Getcat(std::locale::facet const**)
 0xBEDCCC74 cellSailPlayerRegisterSource
 0x24F4ECD3 cellApostSrcGetWorksize
-0x89E5CC7F _ZN3paf8SyncCall4CallEPFiPvES1_
+0x89E5CC7F paf::SyncCall::Call(int (*)(void*), void*)
 0x0A66ACE6 smf_ApPs_GetMediaType
 0x6DF35518 floorl
 0xF843818D cellSpursReadyCountStore
 0x210F6245 cellAsfParser2CheckNeedMem
-0xBA85CE08 _ZNSt12strstreambufD2Ev
-0x8572802A _Z25PSJS_ClassType_NativeFuncv
+0xBA85CE08 std::strstreambuf::~strstreambuf()
+0x8572802A PSJS_ClassType_NativeFunc()
 0x62236E88 SSLCERT_NAME_hash
-0x9CFC0EAF _ZNSiD1Ev
+0x9CFC0EAF std::basic_istream<char, std::char_traits<char>>::~basic_istream()
 0xE509DEEB sceNpInstallerInit
-0x7F4E4139 _ZN4cxml8Document5ClearEv
-0x636169FF _ZN11PSJSContext4LoadEPK8PSJSFile
+0x7F4E4139 cxml::Document::Clear()
+0x636169FF PSJSContext::Load(PSJSFile const*)
 0x0D22867F sceNpMatching2SearchRoom
 0xD0261D72 xSettingRegistryGetInterface
 0xF4A2D52B sceNpClansUpdateMemberInfo
 0x0C9A0EA9 cellSync2QueueTryPop
 0xB30042CE lldiv
 0xDAEADA07 mallopt
-0x7968B603 _ZN3paf5Image4OpenEPKcP12malloc_stateNS_11ImageFormatEjj
+0x7968B603 paf::Image::Open(char const*, malloc_state*, paf::ImageFormat, unsigned int, unsigned int)
 0xC4B6CD8F sceNpScoreGetRankingByNpIdPcIdAsync
 0x112A5EE9 cellSysmoduleUnloadModule
 0x2FA9B538 cellGcmSetFrontFace
@@ -9035,11 +9035,11 @@
 0xC839BB4C sys_rsxaudio_initialize
 0x0B9FEA5F cellHttpRequestGetHeader
 0x94E21701 cellSearchGetContentIdByOffset
-0x47D8CE7C _ZNK10PSJSObject7IsClassEPKt
-0x430FCFED _ZNK3paf4View6NotifyEi
+0x47D8CE7C PSJSObject::IsClass(unsigned short const*) const
+0x430FCFED paf::View::Notify(int) const
 0x24E230D2 _Wctob
 0x59E8DD58 strtoll
-0xECE969C0 _ZTv0_n12_NSt10istrstreamD0Ev
+0xECE969C0 virtual thunk to std::istrstream::~istrstream()
 0xC09E2F23 cellSailAviStreamGetMediaType
 0x1DD3C4CD cellRescGetRegisterCount
 0x0EB4BC38 cellSpursWorkloadAttributeSetShutdownCompletionEventHook
@@ -9057,25 +9057,25 @@
 0xB498BF77 cellSysmoduleUnloadModuleInternal
 0xB276F1F6 cellFontCloseFont
 0xD87D972D cellUsbdResetDevice
-0x202CA2A7 _ZN3paf4View12PageCloseAllEv
+0x202CA2A7 paf::View::PageCloseAll()
 0xB4F4513E _Tgamma
 0x5DBCEEE3 rand_int32_TT800
 0x26B3BC94 sceNpMatchingGetResultGUI
 0x591C21A8 cellHttpClientGetKeepAlive
 0xE3A101E0 cellCryptoPuRsadp1024CRT
-0x8C2E6D06 _ZNKSt8messagesIwE7do_openERKSsRKSt6locale
+0x8C2E6D06 std::messages<wchar_t>::do_open(std::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, std::locale const&) const
 0x34BAB2E1 cellFontsetGetCompositeCodes
 0x531AAB53 cellGcmSetUpdateFragmentProgramParameter
 0x35F21355 cellSyncBarrierWait
-0x3AD12959 _ZNSt9basic_iosIcSt11char_traitsIcEE4initEPSt15basic_streambufIcS1_Eb
+0x3AD12959 std::basic_ios<char, std::char_traits<char>>::init(std::basic_streambuf<char, std::char_traits<char>>*, bool)
 0x0D44F661 cellPrintEndPage
-0xD4A00AE7 _ZN3paf5PhWeb12UISessionPtrD1Ev
-0x79A546A1 _ZN3vsh23FormatFileSizeString_KBEPwij
-0x16DF5ECB _ZNKSt12codecvt_base16do_always_noconvEv
+0xD4A00AE7 paf::PhWeb::UISessionPtr::~UISessionPtr()
+0x79A546A1 vsh::FormatFileSizeString_KB(wchar_t*, int, unsigned int)
+0x16DF5ECB std::codecvt_base::do_always_noconv() const
 0x1855B9B1 setlocale
 0x07254FDA cellSyncBarrierInitialize
 0xC386C116 xCBEnumToNumStr
-0xBDA26024 _ZNSt9strstreamD0Ev
+0xBDA26024 std::strstream::~strstream()
 0xFB02C9D2 cellSslInit
 0xB8E85009 _QN4cell5Daisy22ScatterGatherInterlockC2EPVNS0_16_AtomicInterlockEjPjjh
 0xDEFA1C17 UTF8stoHZs
@@ -9092,9 +9092,9 @@
 0x72257652 cellImeJpDeleteWord
 0x0F03CFB0 cellSaveDataUserListSave
 0xEAEAC87D scePS2McIconSys_GetCopyIconFileName
-0x20183B78 _ZN3paf11PhLabelTextC1EPNS_8PhWidgetEPNS_8PhAppearE
+0x20183B78 paf::PhLabelText::PhLabelText(paf::PhWidget*, paf::PhAppear*)
 0xF798F853 SSLCERT_verify
 0x853E785D sceAdAsyncCacheSpacesCancel
-0xBA6D149A _ZN3paf11PhLabelPrim10WidgetTypeEv
+0xBA6D149A paf::PhLabelPrim::WidgetType()
 0x6C0CFF03 cellRudpEnableInternalIOThread
 0xAA3B4BCD cellFsGetFreeSize


### PR DESCRIPTION
Currently looking into a PS3 binary with debug symbols and was playing around with various tools.

Noticed the Ghidra demangler was breaking things. It produced a lot of '.<type>' resolutions when there should not be any dots, and duplicate placeholder data types in the data type manager created by the demangler -> turned it off and wanted to add my NIDs to the base list.

I used a "particular" reference command line tool which spat out these demangled forms, if you are interested.